### PR TITLE
Mobile hamburger menu + compact footer + layout integrity tests

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+#
+# Prepares the session to run the Playwright mobile layout suite:
+#   - installs JS deps (notion-sync + @playwright/test)
+#   - installs the Chromium browser Playwright drives
+#
+# Runs only in remote (web) sessions; no-op locally so your laptop
+# doesn't get hit every time you start a session.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
+
+echo "[session-start] Installing npm dependencies..."
+npm install --no-audit --no-fund
+
+echo "[session-start] Installing Playwright Chromium..."
+npx --yes playwright install --with-deps chromium
+
+echo "[session-start] Done. Run tests with: npm run test:mobile"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.github/workflows/mobile-layout-check.yml
+++ b/.github/workflows/mobile-layout-check.yml
@@ -1,0 +1,69 @@
+name: Mobile Layout Check
+
+# Runs the Playwright mobile layout suite against the deployed site.
+#
+# Triggers:
+#   • After GitHub Pages finishes publishing a new build from main
+#     (workflow_run on the built-in "pages-build-deployment" workflow).
+#   • A nightly safety net at 12:00 UTC, so we catch any drift even
+#     when nothing has been pushed.
+#   • Manual dispatch, optionally against a different base URL.
+on:
+  workflow_run:
+    workflows: ["pages-build-deployment"]
+    types: [completed]
+  schedule:
+    - cron: "0 12 * * *"
+  workflow_dispatch:
+    inputs:
+      base_url:
+        description: "Base URL to test against"
+        required: false
+        default: "https://eldur.studio"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    # Only run after a *successful* Pages deploy (skip when it failed)
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: "npm"
+
+      - run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Wait for the live site to respond
+        env:
+          BASE_URL: ${{ github.event.inputs.base_url || 'https://eldur.studio' }}
+        run: |
+          for i in 1 2 3 4 5 6 7 8 9 10; do
+            if curl -fsS --max-time 10 "$BASE_URL" > /dev/null; then
+              echo "Site is up on attempt $i"
+              exit 0
+            fi
+            echo "Attempt $i failed, sleeping 10s..."
+            sleep 10
+          done
+          echo "Site did not respond after 10 attempts" >&2
+          exit 1
+
+      - name: Run mobile layout tests
+        env:
+          BASE_URL: ${{ github.event.inputs.base_url || 'https://eldur.studio' }}
+          CI: "true"
+        run: npx playwright test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,9 @@ node_modules/
 _site/
 .jekyll-cache/
 .jekyll-metadata
+
+# Playwright
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -78,6 +78,26 @@
       <div class="nav__links">
         <a href="/results/" class="nav__link">Results</a>
         <a href="/resources/" class="nav__link nav__link--active">Resources</a>
+        <details class="nav__menu">
+          <summary aria-label="Open menu">
+            <span class="nav__toggle">
+              <span class="nav__bar"></span>
+              <span class="nav__bar"></span>
+              <span class="nav__bar"></span>
+            </span>
+          </summary>
+          <div class="nav__mobile-panel">
+            <a href="/results/" class="nav__mobile-link">Results</a>
+            <a href="/resources/" class="nav__mobile-link">Resources</a>
+            <a href="mailto:info@eldur.studio" class="nav__mobile-link nav__mobile-link--muted">
+              <svg width="14" height="14" viewBox="0 0 13 13" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <rect x="0.75" y="2.75" width="11.5" height="7.5" rx="1.25" stroke="currentColor" stroke-width="1.1"/>
+                <path d="M0.75 4.25l5.75 3.5 5.75-3.5" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              info@eldur.studio
+            </a>
+          </div>
+        </details>
         <a href="https://booking.akiflow.com/veronica-es-new" class="btn btn--nav" target="_blank" rel="noopener">Schedule a call</a>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -152,6 +152,26 @@ layout: null
       <div class="nav__links">
         <a href="/results/" class="nav__link">Results</a>
         <a href="/resources/" class="nav__link">Resources</a>
+        <details class="nav__menu">
+          <summary aria-label="Open menu">
+            <span class="nav__toggle">
+              <span class="nav__bar"></span>
+              <span class="nav__bar"></span>
+              <span class="nav__bar"></span>
+            </span>
+          </summary>
+          <div class="nav__mobile-panel">
+            <a href="/results/" class="nav__mobile-link">Results</a>
+            <a href="/resources/" class="nav__mobile-link">Resources</a>
+            <a href="mailto:info@eldur.studio" class="nav__mobile-link nav__mobile-link--muted">
+              <svg width="14" height="14" viewBox="0 0 13 13" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <rect x="0.75" y="2.75" width="11.5" height="7.5" rx="1.25" stroke="currentColor" stroke-width="1.1"/>
+                <path d="M0.75 4.25l5.75 3.5 5.75-3.5" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              info@eldur.studio
+            </a>
+          </div>
+        </details>
         <a href="https://booking.akiflow.com/veronica-es-new" class="btn btn--nav" target="_blank" rel="noopener" onclick="fathom.trackEvent('schedule-call')">Schedule a call</a>
       </div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,9 @@
         "@notionhq/client": "^2.2.15",
         "notion-to-md": "^3.1.1",
         "sharp": "^0.33.0"
+      },
+      "devDependencies": {
+        "@playwright/test": "^1.48.0"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -397,6 +400,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.3.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
@@ -581,6 +600,21 @@
         "node": ">= 6"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -758,6 +792,38 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/repeat-string": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,16 @@
   "version": "1.0.0",
   "private": true,
   "type": "module",
+  "scripts": {
+    "test:mobile": "playwright test",
+    "test:mobile:local": "BASE_URL=http://localhost:4000 playwright test"
+  },
   "dependencies": {
     "@notionhq/client": "^2.2.15",
     "notion-to-md": "^3.1.1",
     "sharp": "^0.33.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.48.0"
   }
 }

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Mobile layout integrity tests for eldur.studio.
+ *
+ * Defaults to running against the live site. Override with:
+ *   BASE_URL=http://localhost:4000 npx playwright test
+ */
+const BASE_URL = process.env.BASE_URL || 'https://eldur.studio';
+
+export default defineConfig({
+  testDir: './tests',
+  timeout: 30_000,
+  expect: { timeout: 8_000 },
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [
+    // iPhone SE — narrowest common mobile viewport (375px). If layout
+    // holds here, it holds on every mainstream phone.
+    { name: 'iPhone SE',          use: { ...devices['iPhone SE'] } },
+    { name: 'iPhone 14',          use: { ...devices['iPhone 14'] } },
+    { name: 'iPhone 14 Pro Max',  use: { ...devices['iPhone 14 Pro Max'] } },
+    { name: 'Pixel 5',            use: { ...devices['Pixel 5'] } },
+  ],
+});

--- a/resources/index.html
+++ b/resources/index.html
@@ -43,6 +43,26 @@ permalink: /resources/
       <div class="nav__links">
         <a href="/results/" class="nav__link">Results</a>
         <a href="/resources/" class="nav__link nav__link--active">Resources</a>
+        <details class="nav__menu">
+          <summary aria-label="Open menu">
+            <span class="nav__toggle">
+              <span class="nav__bar"></span>
+              <span class="nav__bar"></span>
+              <span class="nav__bar"></span>
+            </span>
+          </summary>
+          <div class="nav__mobile-panel">
+            <a href="/results/" class="nav__mobile-link">Results</a>
+            <a href="/resources/" class="nav__mobile-link">Resources</a>
+            <a href="mailto:info@eldur.studio" class="nav__mobile-link nav__mobile-link--muted">
+              <svg width="14" height="14" viewBox="0 0 13 13" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <rect x="0.75" y="2.75" width="11.5" height="7.5" rx="1.25" stroke="currentColor" stroke-width="1.1"/>
+                <path d="M0.75 4.25l5.75 3.5 5.75-3.5" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              info@eldur.studio
+            </a>
+          </div>
+        </details>
         <a href="https://booking.akiflow.com/veronica-es-new" class="btn btn--nav" target="_blank" rel="noopener">Schedule a call</a>
       </div>
     </div>

--- a/results/index.html
+++ b/results/index.html
@@ -43,6 +43,26 @@ permalink: /results/
       <div class="nav__links">
         <a href="/results/" class="nav__link nav__link--active">Results</a>
         <a href="/resources/" class="nav__link">Resources</a>
+        <details class="nav__menu">
+          <summary aria-label="Open menu">
+            <span class="nav__toggle">
+              <span class="nav__bar"></span>
+              <span class="nav__bar"></span>
+              <span class="nav__bar"></span>
+            </span>
+          </summary>
+          <div class="nav__mobile-panel">
+            <a href="/results/" class="nav__mobile-link">Results</a>
+            <a href="/resources/" class="nav__mobile-link">Resources</a>
+            <a href="mailto:info@eldur.studio" class="nav__mobile-link nav__mobile-link--muted">
+              <svg width="14" height="14" viewBox="0 0 13 13" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <rect x="0.75" y="2.75" width="11.5" height="7.5" rx="1.25" stroke="currentColor" stroke-width="1.1"/>
+                <path d="M0.75 4.25l5.75 3.5 5.75-3.5" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              info@eldur.studio
+            </a>
+          </div>
+        </details>
         <a href="https://booking.akiflow.com/veronica-es-new" class="btn btn--nav" target="_blank" rel="noopener">Schedule a call</a>
       </div>
     </div>

--- a/results/people-enrichment-agent/index.html
+++ b/results/people-enrichment-agent/index.html
@@ -70,6 +70,26 @@
       <div class="nav__links">
         <a href="/results/" class="nav__link nav__link--active">Results</a>
         <a href="/resources/" class="nav__link">Resources</a>
+        <details class="nav__menu">
+          <summary aria-label="Open menu">
+            <span class="nav__toggle">
+              <span class="nav__bar"></span>
+              <span class="nav__bar"></span>
+              <span class="nav__bar"></span>
+            </span>
+          </summary>
+          <div class="nav__mobile-panel">
+            <a href="/results/" class="nav__mobile-link">Results</a>
+            <a href="/resources/" class="nav__mobile-link">Resources</a>
+            <a href="mailto:info@eldur.studio" class="nav__mobile-link nav__mobile-link--muted">
+              <svg width="14" height="14" viewBox="0 0 13 13" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+                <rect x="0.75" y="2.75" width="11.5" height="7.5" rx="1.25" stroke="currentColor" stroke-width="1.1"/>
+                <path d="M0.75 4.25l5.75 3.5 5.75-3.5" stroke="currentColor" stroke-width="1.1" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              info@eldur.studio
+            </a>
+          </div>
+        </details>
         <a href="https://booking.akiflow.com/veronica-es-new" class="btn btn--nav" target="_blank" rel="noopener">Schedule a call</a>
       </div>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -1141,14 +1141,55 @@ details[open] > .faq__q::after {
     padding: 0 20px;
   }
 
+  .footer {
+    padding: 40px 0 32px;
+  }
+
   .footer__inner {
     flex-direction: column;
     text-align: center;
-    gap: 28px;
+    gap: 22px;
+  }
+
+  .footer__brand {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
   }
 
   .footer__brand .nav__logo {
     justify-content: center;
+  }
+
+  .footer__brand p {
+    font-size: 13px;
+    margin: 0;
+  }
+
+  .footer__links {
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 10px 18px;
+    width: 100%;
+    max-width: 360px;
+    margin: 0 auto;
+    padding-top: 22px;
+    border-top: 1px solid rgba(255, 255, 255, 0.08);
+  }
+
+  .footer__links a {
+    font-size: 13px;
+    line-height: 1;
+  }
+
+  .footer__contact {
+    flex-basis: 100%;
+    justify-content: center;
+    margin-top: 6px;
+    padding-top: 14px;
+    border-top: 1px solid rgba(255, 255, 255, 0.05);
   }
 }
 
@@ -1171,6 +1212,114 @@ details[open] > .faq__q::after {
 .nav__link:hover,
 .nav__link--active {
   color: var(--white);
+}
+
+/* ============================================
+   MOBILE NAV — hamburger (CSS-only via <details>)
+   ============================================ */
+.nav__menu {
+  display: none; /* shown on mobile only */
+  align-items: center;
+  position: static;
+}
+.nav__menu > summary {
+  display: inline-flex;
+  align-items: center;
+  list-style: none;
+  cursor: pointer;
+  -webkit-tap-highlight-color: transparent;
+}
+.nav__menu > summary::-webkit-details-marker { display: none; }
+.nav__menu > summary::marker { content: ""; }
+
+.nav__toggle {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  background: transparent;
+  transition: background 0.18s ease, border-color 0.18s ease;
+}
+.nav__menu > summary:hover .nav__toggle,
+.nav__menu[open] > summary .nav__toggle {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: rgba(255, 255, 255, 0.22);
+}
+.nav__menu > summary:focus-visible .nav__toggle {
+  outline: 2px solid var(--orange);
+  outline-offset: 2px;
+}
+
+.nav__bar {
+  display: block;
+  width: 18px;
+  height: 2px;
+  background: var(--white);
+  border-radius: 2px;
+  transform-origin: center;
+  transition: transform 0.2s ease, opacity 0.18s ease;
+}
+.nav__menu[open] .nav__bar:nth-child(1) {
+  transform: translateY(7px) rotate(45deg);
+}
+.nav__menu[open] .nav__bar:nth-child(2) {
+  opacity: 0;
+}
+.nav__menu[open] .nav__bar:nth-child(3) {
+  transform: translateY(-7px) rotate(-45deg);
+}
+
+.nav__mobile-panel {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--black);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  padding: 10px 20px 18px;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 16px 40px rgba(0, 0, 0, 0.5);
+  animation: navSlide 0.22s ease;
+}
+@keyframes navSlide {
+  from { opacity: 0; transform: translateY(-6px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.nav__mobile-link {
+  display: flex;
+  align-items: center;
+  padding: 16px 8px;
+  font-size: 17px;
+  font-weight: 500;
+  color: var(--white);
+  text-decoration: none;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  transition: color 0.15s ease;
+}
+.nav__mobile-link:last-child { border-bottom: none; }
+.nav__mobile-link:hover { color: var(--orange); }
+
+.nav__mobile-link--muted {
+  color: rgba(255, 255, 255, 0.55);
+  font-size: 14px;
+  gap: 8px;
+  padding-top: 18px;
+  padding-bottom: 6px;
+}
+.nav__mobile-link--muted:hover { color: var(--white); }
+
+@media (max-width: 720px) {
+  .nav__links { gap: 10px; }
+  .nav__links .nav__link { display: none; }
+  .nav__menu { display: inline-flex; }
 }
 
 /* ============================================

--- a/tests/mobile-layout.spec.js
+++ b/tests/mobile-layout.spec.js
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Mobile layout integrity suite.
+ *
+ * Guards against the two classes of regressions we care about:
+ *   1. Header overflow / CTA clipping on narrow viewports (why the
+ *      hamburger exists in the first place).
+ *   2. Footer items growing past the viewport as we add more links.
+ *
+ * Runs against whatever BASE_URL is configured in playwright.config.js
+ * (default: https://eldur.studio). Executes on every page that ships
+ * the shared nav + footer.
+ */
+const PAGES = ['/', '/results/', '/resources/'];
+
+for (const path of PAGES) {
+  test.describe(`Mobile layout — ${path}`, () => {
+    test.beforeEach(async ({ page }) => {
+      await page.goto(path, { waitUntil: 'networkidle' });
+    });
+
+    test('no horizontal page overflow', async ({ page }) => {
+      const { scrollWidth, clientWidth } = await page.evaluate(() => ({
+        scrollWidth: document.documentElement.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+      }));
+      // 1px slop for sub-pixel rounding
+      expect(scrollWidth).toBeLessThanOrEqual(clientWidth + 1);
+    });
+
+    test('nav shows logo, hamburger, and CTA pill — all within viewport', async ({ page }, testInfo) => {
+      const viewportWidth = page.viewportSize().width;
+
+      const logo = page.locator('.nav .nav__logo').first();
+      const toggle = page.locator('.nav .nav__menu > summary').first();
+      const cta = page.locator('.nav .btn--nav').first();
+
+      await expect(logo).toBeVisible();
+      await expect(toggle).toBeVisible();
+      await expect(cta).toBeVisible();
+
+      // Desktop text links should be hidden at mobile widths
+      const textLinks = page.locator('.nav .nav__links > .nav__link');
+      const textLinkCount = await textLinks.count();
+      for (let i = 0; i < textLinkCount; i++) {
+        await expect(textLinks.nth(i)).toBeHidden();
+      }
+
+      // Every nav element must fit within the viewport horizontally
+      for (const [name, loc] of [['logo', logo], ['toggle', toggle], ['cta', cta]]) {
+        const box = await loc.boundingBox();
+        expect(box, `${name} has a bounding box`).not.toBeNull();
+        expect(box.x, `${name} left edge`).toBeGreaterThanOrEqual(0);
+        expect(box.x + box.width, `${name} right edge`).toBeLessThanOrEqual(viewportWidth + 1);
+      }
+
+      // Hamburger must sit immediately left of the CTA pill
+      const toggleBox = await toggle.boundingBox();
+      const ctaBox = await cta.boundingBox();
+      expect(toggleBox.x + toggleBox.width).toBeLessThanOrEqual(ctaBox.x + 1);
+    });
+
+    test('hamburger opens a panel with Results, Resources and email', async ({ page }) => {
+      const toggle = page.locator('.nav .nav__menu > summary').first();
+      const panel = page.locator('.nav .nav__mobile-panel').first();
+
+      await expect(panel).toBeHidden();
+      await toggle.click();
+      await expect(panel).toBeVisible();
+
+      await expect(panel.getByRole('link', { name: 'Results' })).toBeVisible();
+      await expect(panel.getByRole('link', { name: 'Resources' })).toBeVisible();
+      await expect(panel.getByRole('link', { name: /info@eldur\.studio/ })).toBeVisible();
+
+      // Every panel link must have a non-empty href
+      const links = panel.locator('a');
+      const count = await links.count();
+      expect(count).toBeGreaterThanOrEqual(3);
+      for (let i = 0; i < count; i++) {
+        const href = await links.nth(i).getAttribute('href');
+        expect(href, `panel link ${i} href`).toBeTruthy();
+      }
+    });
+
+    test('footer fits within viewport and all links are visible', async ({ page }) => {
+      const viewportWidth = page.viewportSize().width;
+      const footer = page.locator('.footer').first();
+
+      await footer.scrollIntoViewIfNeeded();
+      await expect(footer).toBeVisible();
+
+      const footerBox = await footer.boundingBox();
+      expect(footerBox.x).toBeGreaterThanOrEqual(0);
+      expect(footerBox.x + footerBox.width).toBeLessThanOrEqual(viewportWidth + 1);
+
+      const links = page.locator('.footer .footer__links a');
+      const count = await links.count();
+      expect(count).toBeGreaterThan(0);
+
+      for (let i = 0; i < count; i++) {
+        const link = links.nth(i);
+        await expect(link).toBeVisible();
+        const box = await link.boundingBox();
+        expect(box, `footer link ${i} bounding box`).not.toBeNull();
+        expect(box.x).toBeGreaterThanOrEqual(0);
+        expect(box.x + box.width).toBeLessThanOrEqual(viewportWidth + 1);
+      }
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Fixes mobile Safari header/footer overflow now that we have more nav items, and wires up a regression net so this doesn't happen again.

### Mobile header (≤720px)
- New CSS-only hamburger button (native `<details>` / `<summary>`) sitting **immediately left of the `Schedule a call` CTA pill**
- Opens a full-width slide-down panel anchored under the nav, containing Results, Resources, and a muted `info@eldur.studio` row
- Bars animate into an X when open; zero JS; keyboard-accessible; closes on navigation
- The old `Results` / `Resources` text links are hidden below 720px so the header no longer overflows on iPhone SE / 14

### Mobile footer (≤640px)
Compact, centered, wrap-friendly layout:
- Logo + tagline, then a thin divider
- Single flex-wrap row of primary links (`Results · Resources · Schedule a call · eldur.studio`) — future links drop straight in without any layout work
- Email pinned below its own subtle divider

### Post-deploy mobile layout integrity tests
- **Playwright suite** at `tests/mobile-layout.spec.js` — 48 tests covering iPhone SE / 14 / 14 Pro Max / Pixel 5 × `/`, `/results/`, `/resources/`
- Asserts: no horizontal page overflow; logo + hamburger + CTA all within viewport; desktop text links hidden; hamburger opens panel with Results / Resources / email; footer and every footer link fit within the viewport
- **GitHub Action** (`.github/workflows/mobile-layout-check.yml`) runs the suite after every successful `pages-build-deployment`, on a daily 12:00 UTC safety net, and via manual dispatch (with optional `base_url` for testing previews)
- **SessionStart hook** (`.claude/hooks/session-start.sh`) installs npm deps + Playwright Chromium automatically for Claude Code on the web

## Test plan

- [ ] Merge → confirm Pages rebuild succeeds
- [ ] Open eldur.studio on iPhone Safari: header fits, hamburger sits left of orange pill, tap expands menu with Results / Resources / info@
- [ ] Scroll to footer on iPhone: links wrap cleanly, email on its own line, nothing spills past the viewport edge
- [ ] Check Actions tab → `Mobile Layout Check` runs after Pages deploy and passes (or fails meaningfully if anything regresses)
- [ ] Verify desktop nav is untouched

https://claude.ai/code/session_019s2VQEyh63H5cF9djH8RRS