### PR TITLE
Install WebKit for Huginn's iPhone device profiles

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -18,7 +18,8 @@ cd "${CLAUDE_PROJECT_DIR:-$(pwd)}"
 echo "[session-start] Installing npm dependencies..."
 npm install --no-audit --no-fund
 
-echo "[session-start] Installing Playwright Chromium..."
-npx --yes playwright install --with-deps chromium
+echo "[session-start] Installing Playwright browsers (Chromium + WebKit)..."
+# WebKit powers the iPhone device profiles; Chromium powers Pixel 5.
+npx --yes playwright install --with-deps chromium webkit
 
 echo "[session-start] Done. Run tests with: npm run test:mobile"

--- a/.github/workflows/mobile-layout-check.yml
+++ b/.github/workflows/mobile-layout-check.yml
@@ -39,8 +39,11 @@ jobs:
 
       - run: npm ci
 
+      # Install both browser engines: WebKit powers the iPhone device
+      # profiles (the engine behind real Mobile Safari — the whole reason
+      # this test suite exists), and Chromium powers the Pixel 5 profile.
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        run: npx playwright install --with-deps chromium webkit
 
       - name: Wait for the live site to respond
         env:


### PR DESCRIPTION
## Summary

Huginn's iPhone tests were all failing with:

```
browserType.launch: Executable doesn't exist at
  /home/runner/.cache/ms-playwright/webkit-2272/pw_run.sh
```

### Why

Playwright's built-in `devices['iPhone SE']`, `devices['iPhone 14']`, and `devices['iPhone 14 Pro Max']` all launch **WebKit** — the engine behind real Mobile Safari — not Chromium. Only `devices['Pixel 5']` uses Chromium.

The workflow was only installing Chromium:

```yaml
run: npx playwright install --with-deps chromium
```

So three of the four projects couldn't even start a browser. That's three quarters of Huginn's coverage, silently broken.

### Fix

Install both engines:

```yaml
run: npx playwright install --with-deps chromium webkit
```

This is actually **the right fix, not a workaround**: the original mobile overflow bug was reported on iPhone Safari. We specifically *want* WebKit in the test loop — Chromium mobile emulation and real WebKit are genuinely different renderers, and only WebKit will catch Safari-specific layout quirks (flexbox edge cases, sticky positioning, `position: absolute` inside `<details>`, etc.).

Same fix applied to `.claude/hooks/session-start.sh` so Claude Code web sessions can run the suite locally without hitting the same error.

## Test plan

- [ ] Merge → wait for Pages to redeploy → watch Huginn's next run in the Actions tab
- [ ] Confirm all 48 checks now run to completion (previously only the 12 Pixel 5 checks did)
- [ ] Any *real* layout regressions that only reproduce in WebKit will now surface — if Huginn fails on this run with real assertions (not browser-launch errors), paste the output and I'll fix

## Trade-off

WebKit's extra system dependencies make the install step ~30s slower. Acceptable price for real Safari coverage on the thing that actually broke in Safari.

https://claude.ai/code/session_019s2VQEyh63H5cF9djH8RRS