### PR TITLE
fix(notion-sync): migrate to dataSources.query for SDK v5

### DIFF
--- a/scripts/notion-sync.js
+++ b/scripts/notion-sync.js
@@ -319,8 +319,20 @@ async function main() {
 
   console.log('Querying Notion database...');
 
-  const response = await notion.databases.query({
+  // Notion API 2025-09-03 split databases into "data sources". The SDK v5
+  // removed `databases.query` — records are now queried via `dataSources.query`.
+  const database = await notion.databases.retrieve({
     database_id: process.env.NOTION_DATABASE_ID,
+  });
+
+  const dataSource = database.data_sources?.[0];
+  if (!dataSource) {
+    console.error(`Error: database ${process.env.NOTION_DATABASE_ID} has no data sources.`);
+    process.exit(1);
+  }
+
+  const response = await notion.dataSources.query({
+    data_source_id: dataSource.id,
     filter: {
       property: 'Status',
       select: { equals: 'Published' },


### PR DESCRIPTION
## Summary

The scheduled Notion sync has been failing on every run since the Dependabot bump of `@notionhq/client` v2.3.0 → v5.20.0 (commit 8bdefa4). The last successful sync was 30d369b — `_posts/` has not been updated since 2026-04-15.

**Root cause:** Notion API `2025-09-03` split databases into one-or-more "data sources". SDK v5 removed `databases.query()` accordingly; records are now queried via `dataSources.query()`. Confirmed against the installed `node_modules/@notionhq/client@5.20.0`:
- `databases` only exposes `retrieve / create / update`.
- `GetDatabaseResponse` now contains `data_sources: Array<{ id, name }>`.
- New `dataSources.query({ data_source_id, filter, sorts, ... })` takes the same filter/sort/result shapes.

So `notion.databases.query(...)` throws `TypeError: notion.databases.query is not a function` and aborts the sync before anything is written.

## Fix

In `scripts/notion-sync.js`, retrieve the database first to resolve its primary data source, then call `dataSources.query` with the same filter/sort. The Eldur Blog database has a single (legacy default) data source, so `data_sources[0]` is correct. Filter/sort/result shapes are unchanged, so the rest of the loop (page properties, `n2m.pageToMarkdown`, image pipeline, front-matter writer) needs no edits.

`notion-to-md@3.1.9` declares a v2 peer-dep but only calls `blocks.children.list`, which is unchanged in v5 — peer-dep warning is cosmetic.

## Test plan

- [ ] Local dry-run: `NOTION_API_KEY=… NOTION_DATABASE_ID=… node scripts/notion-sync.js` — expect `Found N published post(s).` and no `TypeError`.
- [ ] Manual `workflow_dispatch` of Notion Sync against this branch — expect green job and a printed post count in the "Sync posts from Notion" step.
- [ ] After merge, observe the next 2-hourly scheduled run on `main` — expect either a `chore: sync posts from Notion [skip ci]` commit or no-op if Notion has no new content.

https://claude.ai/code/session_013jH4V5quP94HwRezVAyXvF

---
_Generated by [Claude Code](https://claude.ai/code/session_013jH4V5quP94HwRezVAyXvF)_