### PR TITLE
fix: wrap Claim appearance in BlogPosting object for valid JSON-LD

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -87,7 +87,11 @@
   {
     "@context": "https://schema.org",
     "@type": "Claim",
-    "appearance": {{ page.url | absolute_url | jsonify }},
+    "appearance": {
+      "@type": "BlogPosting",
+      "url": {{ page.url | absolute_url | jsonify }},
+      "headline": {{ page.title | jsonify }}
+    },
     "text": {{ page.key_quote | jsonify }},
     "author": { "@id": "https://eldur.studio/#veronica" }
   }


### PR DESCRIPTION
## What changed
In `_layouts/post.html`, the `Claim` JSON-LD block was setting `appearance` to a plain URL string (output by Liquid's `absolute_url` filter). Schema.org requires `appearance` to be a `CreativeWork` typed object, not a bare string.

## Why
Google's Rich Results validator was raising: **"Value of unexpected type for appearance. Expected types: CreativeWork."**

## Fix
Replaced the single URL string with a nested `BlogPosting` object containing `url` and `headline`, both populated dynamically via Liquid:

```json
"appearance": {
  "@type": "BlogPosting",
  "url": "https://eldur.studio/resources/multi-agent-marketing-pyramid/",
  "headline": "The Multi-Agent Marketing Pyramid: Orchestrator + Specialists"
}
```

This applies to all posts (layout is shared), so every post with a `key_quote` will now render valid `Claim` JSON-LD.

## Verification
After deploy, paste any post URL into [Google's Rich Results Test](https://search.google.com/test/rich-results) to confirm the `Claim` block validates without errors.