### PR TITLE
Auto-fix: bump @notionhq/client to 5.22.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "eldur-notion-sync",
       "version": "1.0.0",
       "dependencies": {
-        "@notionhq/client": "^5.21.0",
+        "@notionhq/client": "^5.22.0",
         "notion-to-md": "^3.1.1",
         "sharp": "^0.34.5"
       },
@@ -492,9 +492,9 @@
       }
     },
     "node_modules/@notionhq/client": {
-      "version": "5.21.0",
-      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-5.21.0.tgz",
-      "integrity": "sha512-X+T+hzaQFleOUGm4xUOUm51pOpdZ1+6T4BsRjGlcdEOTJLNkUEv8nZATq9O3ZY4NQEgICc0qwQ0I25OdYprX0w==",
+      "version": "5.22.0",
+      "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-5.22.0.tgz",
+      "integrity": "sha512-lZ3JGBCd6O6MNHWn/58QcUqX1FgmlcODcx/EaUEEpuxLXF5tSi+v29Vzoz8mZ6JgDWDn5pMzzjB69QevYjQQZA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:mobile:local": "BASE_URL=http://localhost:4000 playwright test"
   },
   "dependencies": {
-    "@notionhq/client": "^5.21.0",
+    "@notionhq/client": "^5.22.0",
     "notion-to-md": "^3.1.1",
     "sharp": "^0.34.5"
   },


### PR DESCRIPTION
## What was fixed

**Dependency: `@notionhq/client` 5.21.0 → 5.22.0** — the Notion SDK used by the blog-sync script (`scripts/notion-sync.js`). This version adds a `position` field to the insert-content API endpoint. No breaking changes; Dependabot's [compatibility score](https://docs.github.com/en/github/managing-security-vulnerabilities/about-dependabot-security-updates#about-compatibility-scores) for this bump is high.

This PR supersedes the open [Dependabot PR #19](https://github.com/UberVero/ES2website/pull/19) which proposed the same change.

## What to review

- [`package.json`](package.json) — version constraint updated from `^5.21.0` to `^5.22.0`
- [`package-lock.json`](package-lock.json) — resolved package hashes updated for the new version

No other files were changed.

## What was skipped

- **Dependabot PR #19** — not merged directly; superseded by this PR instead, which consolidates the fix under the autofix workflow.
- **Code scanning alerts (2)** — both are already in `state: "fixed"` on GitHub; no action needed.
- **CI (Playwright mobile layout tests)** — all 3 recent runs passed; no failures to investigate.

---

This PR was created automatically by the site health agent. Please review before merging.