### PR TITLE
Auto-fix: add CollectionPage structured data to /resources/ and /results/ pages

### DIFF
--- a/resources/index.html
+++ b/resources/index.html
@@ -29,6 +29,15 @@ permalink: /resources/
   <link rel="stylesheet" href="/styles.css">
   <link rel="stylesheet" href="/blog.css">
   <script src="https://cdn.usefathom.com/script.js" data-site="FYROQRHW" defer></script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "Resources — Eldur Studio",
+    "description": "Guides, frameworks, and field notes on AI agents, B2B marketing, and one-person teams.",
+    "url": "https://eldur.studio/resources/"
+  }
+  </script>
 </head>
 <body>
 

--- a/results/index.html
+++ b/results/index.html
@@ -30,6 +30,15 @@ permalink: /results/
   <link rel="stylesheet" href="/blog.css">
   <link rel="stylesheet" href="/results.css">
   <script src="https://cdn.usefathom.com/script.js" data-site="FYROQRHW" defer></script>
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "name": "Results — Eldur Studio",
+    "description": "Real client outcomes from AI agent deployments — architecture, metrics, and lessons from live engagements.",
+    "url": "https://eldur.studio/results/"
+  }
+  </script>
 </head>
 <body>
 


### PR DESCRIPTION
## What was fixed

**Issue #23 — Missing structured data on listing pages**

Both `/resources/` and `/results/` were the only pages on the site without JSON-LD structured data (schema markup). Every other page — the homepage, blog posts, and case studies — already has it.

This fix adds a `CollectionPage` schema block to each page's `<head>`. This tells Google these are curated index pages (not thin content), makes the site consistent across all pages, and improves eligibility for rich results in search.

Files changed:
- `resources/index.html` — added `CollectionPage` JSON-LD before `</head>`
- `results/index.html` — added `CollectionPage` JSON-LD before `</head>`

## What to review

The change is 9 lines added to each file, inserted just before the closing `</head>` tag. The schema uses the exact name, description, and URL already defined in each page's Jekyll front matter. You can verify the JSON-LD is valid at [schema.org's validator](https://validator.schema.org).

## What was skipped

**Issue #22 — Case study pages missing from sitemap** — On investigation, this issue is already resolved. The live sitemap at `https://eldur.studio/sitemap.xml` already includes `/results/people-enrichment-agent/` and `/results/scalapay-webflow-directory-headless-cms/`. No fix needed; the issue can be closed.

**PR #19 + PR #20 — `@notionhq/client` dependency bump** — Two open PRs already exist for this (one from Dependabot, one from a previous auto-fix run). No further action needed here.

**Dependabot alerts** — None open.

**Code scanning alerts** — Two previous CodeQL findings are both marked `fixed`. Nothing to act on.

**CI (Playwright mobile tests)** — All 3 recent runs passed. No failures.

---

This PR was created automatically by the site health agent. Please review before merging.