### PR TITLE
Install-agent CTA + button reshape + card motion + /styleguide (design system source of truth)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,9 @@ Every `_posts/*.md` file must have these fields or the sync will skip it:
 
 ## Key architectural decisions
 
-**Style guide is the visual source of truth** — `styleguide/index.html` (served at `/styleguide/`) is a living catalog that renders the brand tokens and every component (buttons, cards, install-agent CTA, gradient metric numbers) straight from the real CSS, plus a "rules & conventions" section. **Read it before building a new page** to see what already exists. It is hand-built static HTML (not Jekyll), `noindex`, and not linked from the site nav.
+**Style guide is the visual source of truth** — `styleguide/index.html` (Jekyll page at `/styleguide/`) is a living catalog with 12 sections (Brand, Color, Typography, Spacing & Radii, Buttons, Install Agent, Cards, Agent Cards, Packages, Eyebrows/Chips/Highlight, Timeline, FAQ). It links the real `/styles.css` so it can't drift, and inlines only its own `sg-*` page chrome (page furniture — never put `sg-*` rules in `styles.css`). It's `noindex` and not in the site nav. **Read it before building a new page.**
+
+**Design changes arrive as repo-token handoffs → PR.** Tokens (`:root`) + component classes live only in `styles.css` (the system of record); `/styleguide/` is the contract. New designs come from the Claude Design project as vanilla CSS patches **already using the repo's own tokens** (`--orange`, `.btn` — not `--es-*`/`.es-btn`), applied to `styles.css` (+ markup, + `assets/<name>.js` loaded `defer`) in a reviewable PR, diffed visually against `/styleguide/`. Add a specimen for every new component. Token-first: brand tweaks are one-line `:root` edits — never hard-code a hex.
 
 **Nav exists in three places** — `index.html`, `_layouts/post.html`, and `resources/index.html`. Changes to nav must be made in all three. Same for the footer.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,11 @@ Every `_posts/*.md` file must have these fields or the sync will skip it:
 
 ## Key architectural decisions
 
+**Style guide is the visual source of truth** — `styleguide/index.html` (served at `/styleguide/`) is a living catalog that renders the brand tokens and every component (buttons, cards, install-agent CTA, gradient metric numbers) straight from the real CSS, plus a "rules & conventions" section. **Read it before building a new page** to see what already exists. It is hand-built static HTML (not Jekyll), `noindex`, and not linked from the site nav.
+
 **Nav exists in three places** — `index.html`, `_layouts/post.html`, and `resources/index.html`. Changes to nav must be made in all three. Same for the footer.
 
-**CSS is one file** — `styles.css` covers homepage, blog posts, resources listing, and case studies. It uses CSS custom properties (see `:root` for all tokens). The README.md brand token table is outdated; always use the `:root` block in `styles.css` as the source of truth.
+**CSS is split by zone** — `styles.css` (homepage + shared: buttons, cards, nav, hero, install-agent), `results.css` (case studies: metric cards, timelines), `blog.css` (blog posts). All use the CSS custom properties in `styles.css` `:root` — the single token source of truth. The README.md brand token table is a mirror that can lag; always use the `:root` block (or the live `/styleguide/`).
 
 **`@font-face` uses root-relative paths** (`/fonts/...`) so fonts load correctly from sub-pages like `/resources/slug/`. Relative paths would break on sub-paths.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Every `_posts/*.md` file must have these fields or the sync will skip it:
 
 ## Key architectural decisions
 
-**Style guide is the visual source of truth** — `styleguide/index.html` (Jekyll page at `/styleguide/`) is a living catalog with 12 sections (Brand, Color, Typography, Spacing & Radii, Buttons, Install Agent, Cards, Agent Cards, Packages, Eyebrows/Chips/Highlight, Timeline, FAQ). It links the real `/styles.css` so it can't drift, and inlines only its own `sg-*` page chrome (page furniture — never put `sg-*` rules in `styles.css`). It's `noindex` and not in the site nav. **Read it before building a new page.**
+**Style guide is the visual source of truth** — `styleguide/index.html` (Jekyll page at `/styleguide/`) is a living catalog (Brand, Color, Typography, Spacing & Radii, Buttons, Install Agent, Cards, Agent Cards, Packages, Chips/Highlight, Timeline, FAQ). It links the real `/styles.css` so it can't drift, and inlines only its own `sg-*` page chrome (page furniture — never put `sg-*` rules in `styles.css`). It's `noindex` and not in the site nav. **Read it before building a new page.**
 
 **Design changes arrive as repo-token handoffs → PR.** Tokens (`:root`) + component classes live only in `styles.css` (the system of record); `/styleguide/` is the contract. New designs come from the Claude Design project as vanilla CSS patches **already using the repo's own tokens** (`--orange`, `.btn` — not `--es-*`/`.es-btn`), applied to `styles.css` (+ markup, + `assets/<name>.js` loaded `defer`) in a reviewable PR, diffed visually against `/styleguide/`. Add a specimen for every new component. Token-first: brand tweaks are one-line `:root` edits — never hard-code a hex.
 

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ production. Open it before building any new page (e.g. the self-service homepage
 python3 -m http.server 3000   # then visit http://localhost:3000/styleguide/
 ```
 
-The 12 sections mirror the design system: **Brand · Color · Typography · Spacing & Radii · Buttons ·
-Install Agent · Cards · Agent Cards · Packages · Eyebrows/Chips/Highlight · Timeline · FAQ**. The page links
+The sections mirror the design system: **Brand · Color · Typography · Spacing & Radii · Buttons ·
+Install Agent · Cards · Agent Cards · Packages · Chips/Highlight · Timeline · FAQ**. The page links
 the real `/styles.css` and inlines only its own `sg-*` page chrome (page furniture — deliberately *not* part
 of the design system).
 

--- a/README.md
+++ b/README.md
@@ -115,31 +115,36 @@ ES2website/
 
 ---
 
-## Style guide
+## Style guide & design system
 
-**Where the visual rules live: [`/styleguide/`](styleguide/index.html)** — a living catalog that renders
-the brand tokens and every component straight from the real CSS (`styles.css` + `results.css`), so it can't
-drift from production. Open it whenever you're building a new page (e.g. the self-service homepage) to see
-what already exists before adding anything.
+**The coded style guide is the source of truth: [`/styleguide/`](styleguide/index.html)** — a living catalog
+that renders every brand token and component straight from the real `styles.css`, so it cannot drift from
+production. Open it before building any new page (e.g. the self-service homepage) to see what already exists.
 
 ```sh
 python3 -m http.server 3000   # then visit http://localhost:3000/styleguide/
 ```
 
-It covers:
-- **Tokens** — colors, the flame `--gradient`, type scale, radii (rendered live, with token names).
-- **Buttons** (`.btn`) — every variant + size, the hover lift, the `.btn__ico` icon nudge, disabled state.
-- **Cards** (`.card`) — agent cards with the `.agent__icon` hover wiggle, link-card lift, dark + package cards.
-- **Install agent** (`.ia2`) — the hero CTA in all three variants, click to play the install animation.
-- **Gradient metric numbers** (`.metric-card`) — the `background-clip: text` figures used on case studies.
-- **Rules & conventions** — token source of truth, where each CSS file applies, class-naming, the
-  nav/footer-in-three-places rule, `prefers-reduced-motion`, and open follow-ups.
+The 12 sections mirror the design system: **Brand · Color · Typography · Spacing & Radii · Buttons ·
+Install Agent · Cards · Agent Cards · Packages · Eyebrows/Chips/Highlight · Timeline · FAQ**. The page links
+the real `/styles.css` and inlines only its own `sg-*` page chrome (page furniture — deliberately *not* part
+of the design system).
 
-Conventions to know before editing styles:
-- **Tokens are the source of truth in `styles.css` `:root`** — never hard-code a hex; add/reuse a token.
-- **CSS is split by zone:** `styles.css` (homepage + shared), `results.css` (case studies), `blog.css` (posts).
-- **Class naming is plain** (`.btn`, `.card`, `.agent__icon`). The design-system handoff ships `--es-*` /
-  `.es-btn` / `.es-card`; those get remapped to these names when applied (see the DS-sync follow-up issue).
+### Keeping the system in sync (the workflow)
+1. **One source of truth, in Git.** Tokens (`:root`) + component classes live in `styles.css`; every page
+   links it. It's versioned — that's the system of record. `/styleguide/` is the human-readable contract.
+2. **Token-first.** Brand changes (accent, radius) are one-line edits to `:root` that propagate everywhere.
+   Never hard-code a hex in markup.
+3. **Design → PR.** Prototype in the Claude Design project; when approved, export a **repo-token handoff**
+   (vanilla CSS patches that already use `--orange`/`.btn`, not `--es-*`/`.es-btn`) and apply it to
+   `styles.css` (+ markup/JS) as a reviewable PR. Diff the PR visually against `/styleguide/`.
+4. **JS components** (e.g. InstallAgent) ship as small `assets/<name>.js`, loaded `defer`, in the same PR.
+5. **Add a specimen for every new component** in `/styleguide/` so the catalog stays complete.
+6. *(Optional, later)* a visual-regression snapshot of `/styleguide/` in CI to catch unintended drift.
+
+> Earlier handoffs shipped `--es-*` / `.es-btn` tokens that had to be hand-remapped to the repo's
+> `--orange` / `.btn`. Handoffs now arrive **pre-mapped to the repo's own tokens**, so applying a design
+> change is a paste-and-review, not a re-type.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -82,11 +82,18 @@ ES2website/
 │   └── [slug]/
 │       └── index.html   # One folder per case study, full design freedom
 │
+├── styleguide/
+│   └── index.html       # Living style guide at /styleguide/ — tokens +
+│                        #   components rendered from the real CSS
+├── results.css          # Case-study styles (metric cards, timelines, …)
+├── blog.css             # Blog-post styles
+│
 ├── assets/
 │   ├── favicon.svg
-│   ├── logo-nav.png     # Nav logo
-│   ├── logo-white.png   # Footer logo (white version)
-│   └── social-card.png  # OG image (1200×630)
+│   ├── logo-nav.png       # Nav logo
+│   ├── logo-white.png     # Footer logo (white version)
+│   ├── social-card.png    # OG image (1200×630)
+│   └── install-agent.js   # InstallAgent CTA animation (idle → installing → done)
 │
 └── fonts/
     ├── BasierCircle-Regular.otf
@@ -108,9 +115,37 @@ ES2website/
 
 ---
 
+## Style guide
+
+**Where the visual rules live: [`/styleguide/`](styleguide/index.html)** — a living catalog that renders
+the brand tokens and every component straight from the real CSS (`styles.css` + `results.css`), so it can't
+drift from production. Open it whenever you're building a new page (e.g. the self-service homepage) to see
+what already exists before adding anything.
+
+```sh
+python3 -m http.server 3000   # then visit http://localhost:3000/styleguide/
+```
+
+It covers:
+- **Tokens** — colors, the flame `--gradient`, type scale, radii (rendered live, with token names).
+- **Buttons** (`.btn`) — every variant + size, the hover lift, the `.btn__ico` icon nudge, disabled state.
+- **Cards** (`.card`) — agent cards with the `.agent__icon` hover wiggle, link-card lift, dark + package cards.
+- **Install agent** (`.ia2`) — the hero CTA in all three variants, click to play the install animation.
+- **Gradient metric numbers** (`.metric-card`) — the `background-clip: text` figures used on case studies.
+- **Rules & conventions** — token source of truth, where each CSS file applies, class-naming, the
+  nav/footer-in-three-places rule, `prefers-reduced-motion`, and open follow-ups.
+
+Conventions to know before editing styles:
+- **Tokens are the source of truth in `styles.css` `:root`** — never hard-code a hex; add/reuse a token.
+- **CSS is split by zone:** `styles.css` (homepage + shared), `results.css` (case studies), `blog.css` (posts).
+- **Class naming is plain** (`.btn`, `.card`, `.agent__icon`). The design-system handoff ships `--es-*` /
+  `.es-btn` / `.es-card`; those get remapped to these names when applied (see the DS-sync follow-up issue).
+
+---
+
 ## Brand tokens
 
-> **Source of truth:** `styles.css` `:root` block. Update this table if you change tokens there.
+> **Source of truth:** `styles.css` `:root` block — see the live [`/styleguide/`](styleguide/index.html) for the rendered version. Update this table if you change tokens there.
 
 | Variable | Value | Use |
 |----------|-------|-----|

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -196,6 +196,11 @@
   </main>
 
   <script>
+  /* Add lazy loading to inline markdown images that the renderer omits it from */
+  document.querySelectorAll('.post-body img:not([loading])').forEach(function(img) {
+    img.setAttribute('loading', 'lazy');
+  });
+
   /* FAQ: detect "## Frequently Asked Questions" section in post body,
      wrap it in an accordion, and inject FAQPage JSON-LD for rich results. */
   (function () {

--- a/assets/install-agent.js
+++ b/assets/install-agent.js
@@ -1,0 +1,115 @@
+/* ============================================================
+   Eldur Studio — InstallAgent (vanilla JS)
+   Drives the install animation: idle → installing → done.
+   - Self-demo: a plain <button data-install-agent> cycles on click.
+   - Stripe link: an <a data-install-agent href="..."> just navigates.
+   - Controlled: add data-controlled and drive it from your app:
+        EldurInstallAgent.setState(el, 'installing');  // after payment
+        EldurInstallAgent.setState(el, 'done');        // after setup
+   The fill sweep is a CSS transition (robust even in background tabs);
+   a timer guarantees completion; rAF only animates the % counter.
+   ============================================================ */
+(function () {
+  var COPY = {
+    installing: ['Installing…', 'Provisioning your agent'],
+    done: ['Agent installed', 'Setup complete'],
+  };
+
+  function setState(el, state) {
+    var dur = parseInt(el.getAttribute('data-duration') || '2200', 10);
+    var fill = el.querySelector('.ia2-fill');
+    var bot  = el.querySelector('.ia2bot');
+    var main = el.querySelector('.ia2-main');
+    var sub  = el.querySelector('.ia2-sub');
+    var idleMain = el.getAttribute('data-label')    || 'Install agent';
+    var idleSub  = el.getAttribute('data-sublabel') || 'Self-service guided setup';
+
+    el.classList.toggle('is-installing', state === 'installing');
+    el.classList.toggle('is-done', state === 'done');
+    if (bot) {
+      bot.classList.toggle('ia2bot--working', state === 'installing');
+      bot.classList.toggle('ia2bot--done', state === 'done');
+    }
+    if (main) main.textContent = state === 'idle' ? idleMain : COPY[state][0];
+    if (sub)  sub.textContent  = state === 'idle' ? idleSub  : COPY[state][1];
+
+    function setFill(t, instant) {
+      if (!fill) return;
+      fill.style.transition = instant ? 'none' : 'transform ' + dur + 'ms cubic-bezier(.4,0,.2,1)';
+      fill.style.transform = 'scaleX(' + t + ')';
+    }
+
+    cancelAnimationFrame(el._raf);
+    clearTimeout(el._to);
+    var pct = el.querySelector('.ia2-pct');
+    if (pct) pct.remove();
+
+    if (state === 'idle') { setFill(0, true); el._state = 'idle'; return; }
+    if (state === 'done') { setFill(1, true); el._state = 'done'; return; }
+
+    /* installing */
+    pct = document.createElement('span');
+    pct.className = 'ia2-pct';
+    pct.textContent = '0%';
+    el.appendChild(pct);
+
+    setFill(0, true);
+    if (fill) void fill.offsetWidth;   // force reflow so the transition runs
+    setFill(1, false);
+
+    var start = performance.now();
+    function tick(now) {
+      var p = Math.min(1, (now - start) / dur);
+      pct.textContent = Math.round(p * 100) + '%';
+      if (p < 1) el._raf = requestAnimationFrame(tick);
+    }
+    el._raf = requestAnimationFrame(tick);
+    el._state = 'installing';
+
+    /* self-demo auto-advances; controlled mode waits for the app */
+    if (!el._controlled) el._to = setTimeout(function () { setState(el, 'done'); }, dur + 60);
+  }
+
+  function onClick(e) {
+    var el = e.currentTarget;
+    if (el.hasAttribute('data-href') || el.tagName === 'A') return; // link navigates
+    if (el._controlled) return;
+    if (el._state === 'installing') { e.preventDefault(); return; }
+    setState(el, el._state === 'done' ? 'idle' : 'installing');
+  }
+
+  /* optional: eyes follow the cursor while idle */
+  function wireEyes(el) {
+    var svg = el.querySelector('.ia2bot svg');
+    var look = el.querySelector('.ia2bot-look');
+    if (!svg || !look) return;
+    var raf = 0;
+    window.addEventListener('mousemove', function (e) {
+      if (raf || el._state !== 'idle') return;
+      raf = requestAnimationFrame(function () {
+        raf = 0;
+        var r = svg.getBoundingClientRect();
+        var dx = e.clientX - (r.left + r.width / 2);
+        var dy = e.clientY - (r.top + r.height * 0.46);
+        var d = Math.hypot(dx, dy) || 1;
+        look.setAttribute('transform', 'translate(' + (dx / d * 1.9).toFixed(2) + ' ' + (dy / d * 1.9).toFixed(2) + ')');
+      });
+    }, { passive: true });
+  }
+
+  function mount(el) {
+    el._state = 'idle';
+    el._controlled = el.hasAttribute('data-controlled');
+    el.addEventListener('click', onClick);
+    wireEyes(el);
+    setState(el, 'idle');
+  }
+
+  function init(root) {
+    (root || document).querySelectorAll('[data-install-agent]').forEach(mount);
+  }
+
+  window.EldurInstallAgent = { init: init, mount: mount, setState: setState };
+  if (document.readyState !== 'loading') init();
+  else document.addEventListener('DOMContentLoaded', function () { init(); });
+})();

--- a/index.html
+++ b/index.html
@@ -185,6 +185,41 @@ layout: null
         <h1 class="hero__headline">Build the one&#8209;person<br>marketing team</h1>
         <p class="hero__sub">We build AI agents that handle your marketing and sales ops work, then hand you systems your team runs without us.</p>
         <div class="hero__actions">
+          <button class="ia2 ia2--dark" data-install-agent
+                  data-label="Install agent" data-sublabel="Self-service guided setup"
+                  aria-live="polite">
+            <span class="ia2-fill"></span>
+            <span class="ia2-bot">
+              <span class="ia2bot">
+                <svg width="36" height="36" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="install agent">
+                  <g class="ia2bot-all">
+                    <line x1="24" y1="12" x2="24" y2="6.5" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/>
+                    <g transform="translate(24 3)"><g class="ia2bot-tip">
+                      <path d="M0 -3.4 L1 -1 L3.4 0 L1 1 L0 3.4 L-1 1 L-3.4 0 L-1 -1 Z" fill="currentColor"/>
+                    </g></g>
+                    <rect x="5.6" y="20" width="3" height="9" rx="1.5" fill="currentColor"/>
+                    <rect x="39.4" y="20" width="3" height="9" rx="1.5" fill="currentColor"/>
+                    <rect x="9" y="12" width="30" height="26" rx="8.5" fill="none" stroke="currentColor" stroke-width="2.4"/>
+                    <g class="ia2bot-look">
+                      <g class="ia2bot-eyes">
+                        <circle cx="18" cy="24" r="2.7" fill="currentColor"/>
+                        <circle cx="30" cy="24" r="2.7" fill="currentColor"/>
+                      </g>
+                      <path d="M19.5 30.6 Q24 34 28.5 30.6" stroke="currentColor" stroke-width="1.9" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+                    </g>
+                    <g class="ia2bot-check" transform="translate(34 33)">
+                      <circle r="6.4" fill="currentColor"/>
+                      <path d="M-3 0.2 L-0.8 2.4 L3.2 -2.2" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+                    </g>
+                  </g>
+                </svg>
+              </span>
+            </span>
+            <span class="ia2-label">
+              <span class="ia2-main">Install agent</span>
+              <span class="ia2-sub">Self-service guided setup</span>
+            </span>
+          </button>
           <a href="https://booking.akiflow.com/veronica-es-new" class="btn btn--primary" target="_blank" rel="noopener" onclick="fathom.trackEvent('schedule-call')">Schedule a call</a>
           <a href="#packages" class="btn btn--ghost">View packages</a>
         </div>
@@ -687,6 +722,8 @@ layout: null
     };
   })();
   </script>
+
+  <script src="assets/install-agent.js" defer></script>
 
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -185,41 +185,6 @@ layout: null
         <h1 class="hero__headline">Build the one&#8209;person<br>marketing team</h1>
         <p class="hero__sub">We build AI agents that handle your marketing and sales ops work, then hand you systems your team runs without us.</p>
         <div class="hero__actions">
-          <button class="ia2 ia2--dark" data-install-agent
-                  data-label="Install agent" data-sublabel="Self-service guided setup"
-                  aria-live="polite">
-            <span class="ia2-fill"></span>
-            <span class="ia2-bot">
-              <span class="ia2bot">
-                <svg width="36" height="36" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="install agent">
-                  <g class="ia2bot-all">
-                    <line x1="24" y1="12" x2="24" y2="6.5" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/>
-                    <g transform="translate(24 3)"><g class="ia2bot-tip">
-                      <path d="M0 -3.4 L1 -1 L3.4 0 L1 1 L0 3.4 L-1 1 L-3.4 0 L-1 -1 Z" fill="currentColor"/>
-                    </g></g>
-                    <rect x="5.6" y="20" width="3" height="9" rx="1.5" fill="currentColor"/>
-                    <rect x="39.4" y="20" width="3" height="9" rx="1.5" fill="currentColor"/>
-                    <rect x="9" y="12" width="30" height="26" rx="8.5" fill="none" stroke="currentColor" stroke-width="2.4"/>
-                    <g class="ia2bot-look">
-                      <g class="ia2bot-eyes">
-                        <circle cx="18" cy="24" r="2.7" fill="currentColor"/>
-                        <circle cx="30" cy="24" r="2.7" fill="currentColor"/>
-                      </g>
-                      <path d="M19.5 30.6 Q24 34 28.5 30.6" stroke="currentColor" stroke-width="1.9" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-                    </g>
-                    <g class="ia2bot-check" transform="translate(34 33)">
-                      <circle r="6.4" fill="currentColor"/>
-                      <path d="M-3 0.2 L-0.8 2.4 L3.2 -2.2" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-                    </g>
-                  </g>
-                </svg>
-              </span>
-            </span>
-            <span class="ia2-label">
-              <span class="ia2-main">Install agent</span>
-              <span class="ia2-sub">Self-service guided setup</span>
-            </span>
-          </button>
           <a href="https://booking.akiflow.com/veronica-es-new" class="btn btn--primary" target="_blank" rel="noopener" onclick="fathom.trackEvent('schedule-call')">Schedule a call</a>
           <a href="#packages" class="btn btn--ghost">View packages</a>
         </div>
@@ -722,8 +687,6 @@ layout: null
     };
   })();
   </script>
-
-  <script src="assets/install-agent.js" defer></script>
 
 </body>
 </html>

--- a/results.css
+++ b/results.css
@@ -621,6 +621,7 @@
 }
 
 .metric-card__value {
+  font-family: var(--font-heading);
   font-size: clamp(32px, 4vw, 44px);
   font-weight: 700;
   letter-spacing: -0.03em;

--- a/results.css
+++ b/results.css
@@ -621,9 +621,10 @@
 }
 
 .metric-card__value {
-  font-size: clamp(32px, 4vw, 44px);
-  font-weight: 700;
-  letter-spacing: -0.03em;
+  font-family: var(--font-heading);
+  font-size: clamp(36px, 4.4vw, 48px);
+  font-weight: 400;
+  letter-spacing: -0.01em;
   line-height: 1;
   background: var(--gradient);
   -webkit-background-clip: text;

--- a/results.css
+++ b/results.css
@@ -621,10 +621,9 @@
 }
 
 .metric-card__value {
-  font-family: var(--font-heading);
-  font-size: clamp(36px, 4.4vw, 48px);
-  font-weight: 400;
-  letter-spacing: -0.01em;
+  font-size: clamp(32px, 4vw, 44px);
+  font-weight: 700;
+  letter-spacing: -0.03em;
   line-height: 1;
   background: var(--gradient);
   -webkit-background-clip: text;

--- a/styleguide/index.html
+++ b/styleguide/index.html
@@ -1,332 +1,454 @@
+---
+layout: null
+---
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="robots" content="noindex, nofollow">
-  <title>Eldur Studio — Style Guide</title>
-  <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Eldur Studio — Design System & Style Guide</title>
+<meta name="robots" content="noindex, nofollow">
+<link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
+<link rel="stylesheet" href="/styles.css">
+<style>
+/* Page furniture for /styleguide/ only — NOT part of the design system.
+   The design-system CSS lives in /styles.css (the source of truth). */
+/* ============================================
+   STYLEGUIDE PAGE CHROME  (sg-* — not shipped in styles.css)
+   ============================================ */
+.sg-body { font-family: var(--font); color: var(--black); background: var(--white); }
+.sg-top { position: sticky; top: 0; z-index: 50; background: var(--black); color: #fff; padding: 18px 40px; display: flex; align-items: baseline; gap: 16px; border-bottom: 1px solid rgba(255,255,255,.08); }
+.sg-top__mark { font-family: var(--font-heading); font-size: 22px; letter-spacing: .02em; }
+.sg-top__tag { font-size: 12px; color: var(--orange); font-weight: 700; text-transform: uppercase; letter-spacing: .14em; }
+.sg-top__meta { margin-left: auto; font-size: 12px; color: rgba(255,255,255,.5); }
+.sg-wrap { max-width: 1080px; margin: 0 auto; padding: 0 40px 120px; }
+.sg-sec { padding: 64px 0 8px; border-bottom: 1px solid var(--border); }
+.sg-sec:last-child { border-bottom: none; }
+.sg-kicker { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: .14em; color: var(--orange); margin-bottom: 10px; }
+.sg-h2 { font-size: 30px; font-weight: 700; letter-spacing: -.02em; margin-bottom: 8px; }
+.sg-lead { font-size: 16px; color: #555; line-height: 1.6; max-width: 640px; margin-bottom: 36px; }
+.sg-block { margin-bottom: 40px; }
+.sg-label { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 11px; text-transform: uppercase; letter-spacing: .1em; color: #999; margin-bottom: 16px; display: block; }
+.sg-row { display: flex; gap: 16px; align-items: center; flex-wrap: wrap; }
+.sg-stage { padding: 36px; border-radius: var(--radius-lg); border: 1px solid var(--border); }
+.sg-stage--dark { background: var(--black); border-color: rgba(255,255,255,.1); }
+.sg-stage--light { background: var(--gray); border-color: transparent; }
+.sg-note { font-size: 13px; color: #777; line-height: 1.6; margin-top: 14px; }
+.sg-note code, .sg-code { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 12.5px; background: #f3f3f5; border: 1px solid var(--border); border-radius: 6px; padding: 2px 6px; color: #b8430f; }
+.sg-pre { font-family: ui-monospace, 'SF Mono', Menlo, monospace; font-size: 12.5px; line-height: 1.7; background: #0e0e0e; color: #e6e6e6; border-radius: var(--radius); padding: 20px 22px; overflow-x: auto; margin-top: 16px; }
+.sg-pre .c { color: #ff9a4d; }
+.sg-pre .k { color: #ffc109; }
 
-  <!-- The real site CSS. This page renders live components straight from
-       these files, so it can never drift from production. Root-relative
-       paths resolve both on eldur.studio and at /styleguide/ locally. -->
-  <link rel="stylesheet" href="/styles.css">
-  <link rel="stylesheet" href="/results.css">
+/* color swatches */
+.sg-swatches { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 14px; }
+.sg-sw { border: 1px solid var(--border); border-radius: var(--radius); overflow: hidden; }
+.sg-sw__chip { height: 76px; }
+.sg-sw__meta { padding: 10px 12px; }
+.sg-sw__name { font-size: 13px; font-weight: 700; }
+.sg-sw__val { font-family: ui-monospace, monospace; font-size: 11px; color: #888; margin-top: 2px; }
 
-  <style>
-    /* ----- Page-local layout only (prefixed `sg-`, no brand tokens defined here) ----- */
-    body.sg { font-size: 16px; background: var(--white); color: var(--black); }
-    .sg-wrap { max-width: 1100px; margin: 0 auto; padding: 48px 32px 96px; }
-    .sg-header { border-bottom: 1px solid var(--border); padding-bottom: 28px; margin-bottom: 48px; }
-    .sg-header h1 { font-family: var(--font-heading); font-size: clamp(34px, 5vw, 52px); line-height: 1.05; letter-spacing: -0.02em; margin-bottom: 14px; }
-    .sg-header p { font-size: 17px; line-height: 1.6; color: #444; max-width: 680px; }
-    .sg-toc { display: flex; flex-wrap: wrap; gap: 10px 18px; margin-top: 22px; font-size: 14px; }
-    .sg-toc a { color: var(--orange); text-decoration: none; font-weight: 600; }
-    .sg-toc a:hover { text-decoration: underline; }
+/* type specimens */
+.sg-type { display: flex; flex-direction: column; gap: 26px; }
+.sg-type__row { display: grid; grid-template-columns: 120px 1fr; gap: 24px; align-items: baseline; border-top: 1px solid var(--border); padding-top: 20px; }
+.sg-type__meta { font-family: ui-monospace, monospace; font-size: 11px; color: #999; line-height: 1.6; }
 
-    .sg-section { margin-bottom: 64px; scroll-margin-top: 24px; }
-    .sg-section > h2 { font-family: var(--font-heading); font-size: 28px; letter-spacing: -0.01em; margin-bottom: 6px; }
-    .sg-section > .sg-lead { color: #555; font-size: 15px; line-height: 1.6; margin-bottom: 24px; max-width: 720px; }
-    .sg-subhead { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: #888; margin: 28px 0 14px; }
+/* spec table */
+.sg-table { width: 100%; border-collapse: collapse; font-size: 14px; }
+.sg-table th, .sg-table td { text-align: left; padding: 11px 14px; border-bottom: 1px solid var(--border); }
+.sg-table th { font-size: 11px; text-transform: uppercase; letter-spacing: .08em; color: #999; }
+.sg-table td code { font-family: ui-monospace, monospace; font-size: 12.5px; color: #b8430f; }
 
-    /* a labelled demo panel — `dark` for components that live on black sections */
-    .sg-panel { border: 1.5px solid var(--border); border-radius: var(--radius-lg); padding: 28px; background: var(--white); }
-    .sg-panel--dark { background: var(--black); border-color: rgba(255,255,255,0.12); }
-    .sg-panel--slate { background: var(--gray); }
-    .sg-row { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; }
-    .sg-stack { display: flex; flex-direction: column; gap: 14px; align-items: flex-start; }
+/* radii demo */
+.sg-radii { display: flex; gap: 18px; flex-wrap: wrap; }
+.sg-radius { width: 92px; height: 64px; background: var(--orange-dim); border: 1.5px solid var(--orange); display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 600; color: #b8430f; }
 
-    /* token: color swatches */
-    .sg-swatches { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 14px; }
-    .sg-swatch { border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
-    .sg-swatch__chip { height: 72px; }
-    .sg-swatch__meta { padding: 10px 12px; font-size: 12px; line-height: 1.5; }
-    .sg-swatch__meta code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; color: #333; }
-    .sg-swatch__meta b { display: block; font-size: 13px; }
+/* TOC */
+.sg-toc { display: flex; flex-wrap: wrap; gap: 8px 18px; padding: 22px 0 4px; }
+.sg-toc a { font-size: 13px; color: #666; }
+.sg-toc a:hover { color: var(--orange); }
 
-    /* token: radii + type samples */
-    .sg-radii { display: flex; gap: 18px; flex-wrap: wrap; }
-    .sg-radius { width: 120px; height: 80px; background: var(--orange-dim); border: 1.5px solid var(--orange); display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 600; color: var(--orange); }
-
-    .sg-code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px; background: #f4f4f5; border: 1px solid var(--border); border-radius: 8px; padding: 2px 7px; color: #b3360b; white-space: nowrap; }
-    .sg-note { font-size: 13px; color: #777; margin-top: 10px; line-height: 1.6; }
-    .sg-rules { font-size: 15px; line-height: 1.75; color: #333; }
-    .sg-rules li { margin-bottom: 10px; }
-    .sg-rules code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; background: #f4f4f5; padding: 1px 6px; border-radius: 5px; color: #b3360b; }
-  </style>
+/* page-chrome responsiveness (keeps specimens inside narrow viewports) */
+@media (max-width: 640px) {
+  .sg-top { padding: 14px 16px; }
+  .sg-wrap { padding: 0 14px 80px; }
+  .sg-stage { padding: 16px; }
+  .sg-type__row { grid-template-columns: 1fr; gap: 8px; }
+  .sg-table { display: block; overflow-x: auto; white-space: nowrap; }
+}
+</style>
 </head>
-<body class="sg">
-  <div class="sg-wrap">
+<body class="sg-body">
 
-    <header class="sg-header">
-      <h1>Eldur Studio — Style Guide</h1>
-      <p>
-        The living catalog of brand tokens and components, rendered straight from the
-        production CSS (<span class="sg-code">styles.css</span> + <span class="sg-code">results.css</span>) — so it
-        can't drift from the real site. This is the visual reference that used to live only in the
-        design-system project's <span class="sg-code">visual-reference/exploration.html</span>.
-        <strong>Source of truth for all tokens is the <span class="sg-code">:root</span> block in
-        <span class="sg-code">styles.css</span></strong> (the README brand-token table is outdated).
-      </p>
-      <nav class="sg-toc">
-        <a href="#tokens">Tokens</a>
-        <a href="#buttons">Buttons</a>
-        <a href="#cards">Cards</a>
-        <a href="#install">Install agent</a>
-        <a href="#metrics">Metric numbers</a>
-        <a href="#rules">Rules &amp; conventions</a>
-      </nav>
-    </header>
+<header class="sg-top">
+  <span class="sg-top__mark">Eldur Studio</span>
+  <span class="sg-top__tag">Design System</span>
+  <span class="sg-top__meta">Living style guide · source of truth: <code>styles.css</code></span>
+</header>
 
-    <!-- ============================= TOKENS ============================= -->
-    <section class="sg-section" id="tokens">
-      <h2>Design tokens</h2>
-      <p class="sg-lead">CSS custom properties defined in <span class="sg-code">styles.css :root</span>. Use the token, never a raw hex.</p>
+<div class="sg-wrap">
 
-      <div class="sg-subhead">Color</div>
-      <div class="sg-swatches">
-        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:#000000"></div><div class="sg-swatch__meta"><b>--black</b><code>#000000</code></div></div>
-        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:#111111"></div><div class="sg-swatch__meta"><b>--dark</b><code>#111111</code></div></div>
-        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:#ff7a00"></div><div class="sg-swatch__meta"><b>--orange</b><code>#ff7a00</code></div></div>
-        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:#ff7a00;opacity:.08"></div><div class="sg-swatch__meta"><b>--orange-dim</b><code>rgba(255,122,0,.08)</code></div></div>
-        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:#ee0f0f"></div><div class="sg-swatch__meta"><b>--red</b><code>#ee0f0f</code></div></div>
-        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:#ffc109"></div><div class="sg-swatch__meta"><b>--yellow</b><code>#ffc109</code></div></div>
-        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:linear-gradient(90deg,#ff7a00 0%,#ee0f0f 100%)"></div><div class="sg-swatch__meta"><b>--gradient</b><code>orange → red, 90deg</code></div></div>
-        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:#FFFFFF;border-bottom:1px solid var(--border)"></div><div class="sg-swatch__meta"><b>--white</b><code>#FFFFFF</code></div></div>
-        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:#EFEFF1"></div><div class="sg-swatch__meta"><b>--gray</b><code>#EFEFF1</code></div></div>
+  <nav class="sg-toc">
+    <a href="#brand">Brand</a>
+    <a href="#color">Color</a>
+    <a href="#type">Typography</a>
+    <a href="#space">Spacing &amp; Radii</a>
+    <a href="#buttons">Buttons</a>
+    <a href="#install">Install Agent</a>
+    <a href="#cards">Cards</a>
+    <a href="#agent">Agent Cards</a>
+    <a href="#packages">Packages</a>
+    <a href="#bits">Eyebrows · Chips · Highlight</a>
+    <a href="#timeline">Timeline</a>
+    <a href="#faq">FAQ</a>
+  </nav>
+
+  <!-- ============ BRAND ============ -->
+  <section class="sg-sec" id="brand">
+    <p class="sg-kicker">01 — Brand</p>
+    <h2 class="sg-h2">Eldur is Icelandic for <em style="font-style:italic;color:var(--orange)">fire</em>.</h2>
+    <p class="sg-lead">A hot orange-on-black system for a B2B agency that installs AI agents. Confident, warm, technical. The wordmark is set in Kamura; everything else is Basier Circle. Orange (<code class="sg-code">--orange</code>) is the single accent — used sparingly against deep black and clean light-gray surfaces.</p>
+    <div class="sg-row">
+      <div class="sg-stage sg-stage--dark" style="flex:1; min-width:260px;">
+        <span class="sg-label" style="color:rgba(255,255,255,.4)">Wordmark on black</span>
+        <div style="font-family:var(--font-heading); font-size:40px; color:#fff; letter-spacing:.02em;">Eldur Studio</div>
       </div>
-      <p class="sg-note">On dark sections, body text uses <span class="sg-code">--text-muted</span> (<code>rgba(255,255,255,.65)</code>); hairline dividers use <span class="sg-code">--border</span> (<code>rgba(0,0,0,.10)</code>).</p>
-
-      <div class="sg-subhead">Type</div>
-      <div class="sg-panel">
-        <p style="font-family:var(--font-heading);font-size:48px;line-height:1;letter-spacing:-0.01em;margin-bottom:6px;">95% · 200h → 2h</p>
-        <p style="font-family:var(--font-heading);font-size:28px;line-height:1.05;margin-bottom:18px;color:#555;">Kamura — display serif: the nav wordmark and big metric numbers</p>
-        <p style="font-family:var(--font);font-size:clamp(38px,5vw,56px);font-weight:700;line-height:1.08;letter-spacing:-0.03em;margin-bottom:14px;">Build the one&#8209;person marketing team</p>
-        <p style="font-family:var(--font);font-size:13px;color:#888;margin-bottom:18px;">↑ Hero headlines &amp; section titles are <strong>Basier Circle Bold</strong>, <em>not</em> Kamura.</p>
-        <p style="font-family:var(--font);font-size:17px;font-weight:600;margin-bottom:4px;">Basier Circle SemiBold 600 — buttons, labels, eyebrows</p>
-        <p style="font-family:var(--font);font-size:16px;font-weight:400;color:#444;">Basier Circle Regular 400 — body copy. The quick brown fox jumps over the lazy dog.</p>
-        <p class="sg-note"><span class="sg-code">--font-heading</span> = Kamura (serif display — reserved for the wordmark and large numerals). <span class="sg-code">--font</span> = Basier Circle (weights 400/500/600/700) for <strong>everything else, including the hero headline and section titles</strong>. Fonts load via root-relative <span class="sg-code">@font-face</span> paths so they work from sub-pages.</p>
+      <div class="sg-stage sg-stage--light" style="flex:1; min-width:260px;">
+        <span class="sg-label">Wordmark on light</span>
+        <div style="font-family:var(--font-heading); font-size:40px; color:var(--black); letter-spacing:.02em;">Eldur Studio</div>
       </div>
+    </div>
+  </section>
 
-      <div class="sg-subhead">Eyebrow (<span class="sg-code">.eyebrow</span>)</div>
-      <div class="sg-panel">
-        <p class="eyebrow">Custom AI agents for growth</p>
-        <p class="sg-note">The small uppercase kicker above a headline/section title: <span class="sg-code">--red</span>, 12px/700, <span class="sg-code">0.12em</span> tracking. Used in the hero and at the top of most sections. On dark sections it sits above white headings; here on light it keeps its red.</p>
+  <!-- ============ COLOR ============ -->
+  <section class="sg-sec" id="color">
+    <p class="sg-kicker">02 — Color</p>
+    <h2 class="sg-h2">Palette &amp; tokens</h2>
+    <p class="sg-lead">Every color is a CSS variable in <code class="sg-code">:root</code>. Reach for the token, never a raw hex. The flame gradient is reserved for the loudest moments (hero install, key CTAs, the timeline spine).</p>
+    <div class="sg-swatches" id="swatches"></div>
+    <div class="sg-block" style="margin-top:28px">
+      <span class="sg-label">--gradient (flame)</span>
+      <div style="height:64px; border-radius:var(--radius); background:var(--gradient);"></div>
+    </div>
+  </section>
+
+  <!-- ============ TYPE ============ -->
+  <section class="sg-sec" id="type">
+    <p class="sg-kicker">03 — Typography</p>
+    <h2 class="sg-h2">Type scale</h2>
+    <p class="sg-lead">Two families: <strong>Kamura</strong> (serif display — wordmark only) and <strong>Basier Circle</strong> (everything else, weights 400–700). Headlines run tight (<code class="sg-code">-0.03em</code>); body is a comfortable 1.65.</p>
+    <div class="sg-type">
+      <div class="sg-type__row">
+        <div class="sg-type__meta">Hero headline<br>Basier 700<br>clamp 38–62px</div>
+        <div style="font-size:clamp(34px,4vw,52px); font-weight:700; line-height:1.08; letter-spacing:-0.03em;">Put an AI agent to work this week</div>
       </div>
+      <div class="sg-type__row">
+        <div class="sg-type__meta">Section title<br>Basier 700<br>clamp 28–42px</div>
+        <div style="font-size:clamp(26px,3vw,38px); font-weight:700; line-height:1.12; letter-spacing:-0.025em;">Agents that earn their seat</div>
+      </div>
+      <div class="sg-type__row">
+        <div class="sg-type__meta">Lead<br>Basier 400<br>18px / 1.6</div>
+        <div style="font-size:18px; line-height:1.6; color:#4a4a4a; max-width:560px;">We design, build, and install custom agents into your stack — monitored, qualified, and reporting from day one.</div>
+      </div>
+      <div class="sg-type__row">
+        <div class="sg-type__meta">Body<br>Basier 400<br>16px / 1.65</div>
+        <div style="font-size:16px; line-height:1.65; color:#333; max-width:560px;">The workhorse paragraph size. Used in cards, FAQ answers, and long-form copy across the site. Readable, unhurried, never cramped.</div>
+      </div>
+      <div class="sg-type__row">
+        <div class="sg-type__meta">Eyebrow<br>Basier 700<br>12px · 0.12em</div>
+        <div><span class="eyebrow">How it works</span></div>
+      </div>
+    </div>
+  </section>
 
-      <div class="sg-subhead">Radius</div>
+  <!-- ============ SPACING + RADII ============ -->
+  <section class="sg-sec" id="space">
+    <p class="sg-kicker">04 — Spacing &amp; Radii</p>
+    <h2 class="sg-h2">Rhythm &amp; corners</h2>
+    <p class="sg-lead">Generous vertical rhythm — sections breathe at 96px (64px compact). Three corner radii cover everything; the pill is now reserved for tags only.</p>
+    <div class="sg-block">
+      <span class="sg-label">Corner radii</span>
       <div class="sg-radii">
-        <div class="sg-radius" style="border-radius:12px">--radius · 12px</div>
-        <div class="sg-radius" style="border-radius:20px">--radius-lg · 20px</div>
-        <div class="sg-radius" style="border-radius:100px">pill · 100px</div>
+        <div class="sg-radius" style="border-radius:12px">12px<br>default</div>
+        <div class="sg-radius" style="border-radius:20px">20px<br>cards</div>
+        <div class="sg-radius" style="border-radius:100px; width:120px">100px<br>tags only</div>
       </div>
-    </section>
+    </div>
+    <table class="sg-table">
+      <thead><tr><th>Token</th><th>Value</th><th>Use</th></tr></thead>
+      <tbody>
+        <tr><td><code>--radius</code></td><td>12px</td><td>Buttons, inputs, install CTA, callouts</td></tr>
+        <tr><td><code>--radius-lg</code></td><td>20px</td><td>Cards, panels, modals</td></tr>
+        <tr><td><code>--max-w</code></td><td>1160px</td><td>Page container</td></tr>
+        <tr><td><code>.section</code></td><td>96px</td><td>Vertical section padding (64px compact)</td></tr>
+      </tbody>
+    </table>
+  </section>
 
-    <!-- ============================= BUTTONS ============================= -->
-    <section class="sg-section" id="buttons">
-      <h2>Button — <span class="sg-code">.btn</span></h2>
-      <p class="sg-lead">A confident 12px rounded rectangle (was a 100px pill): 17px/700 type, a hover micro-lift + flame glow, and a trailing icon that nudges. Wrap icons in <span class="sg-code">.btn__ico</span> so they animate.</p>
+  <!-- ============ BUTTONS ============ -->
+  <section class="sg-sec" id="buttons">
+    <p class="sg-kicker">05 — Buttons</p>
+    <h2 class="sg-h2">Buttons <span style="font-size:14px; color:var(--orange); font-weight:700; letter-spacing:.06em; text-transform:uppercase; vertical-align:middle;">· updated</span></h2>
+    <p class="sg-lead">The pill is retired. Buttons are now a confident <strong>12px rounded rectangle</strong> — bigger (16/30 padding, 17px → wait 16px/700), they <strong>lift 2px</strong> on hover with a flame glow, and a trailing icon nudges right. New <code class="sg-code">.btn--gradient</code> for flame moments.</p>
 
-      <div class="sg-subhead">Variants on dark (ghost / outline-white / white are for dark sections)</div>
-      <div class="sg-panel sg-panel--dark">
+    <div class="sg-block">
+      <span class="sg-label">Before → after</span>
+      <div class="sg-stage sg-stage--light">
+        <div class="sg-row" style="gap:32px">
+          <div style="text-align:center">
+            <span style="display:inline-flex; align-items:center; gap:8px; padding:14px 28px; border-radius:100px; background:var(--orange); color:#fff; font-family:var(--font); font-size:15px; font-weight:600;">Schedule a call</span>
+            <div style="font-family:ui-monospace,monospace; font-size:10px; color:#999; margin-top:10px; text-transform:uppercase; letter-spacing:.1em;">Old · 100px pill</div>
+          </div>
+          <div style="font-size:24px; color:var(--orange);">→</div>
+          <div style="text-align:center">
+            <a class="btn btn--primary" href="javascript:void(0)">Schedule a call <span class="btn__ico" aria-hidden="true"><svg width="18" height="18" viewBox="0 0 18 18" fill="none"><path d="M3 9h11M9.5 4.5L14 9l-4.5 4.5" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round"/></svg></span></a>
+            <div style="font-family:ui-monospace,monospace; font-size:10px; color:var(--orange); margin-top:10px; text-transform:uppercase; letter-spacing:.1em;">New · 12px · lifts</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="sg-block">
+      <span class="sg-label">Variants — on dark</span>
+      <div class="sg-stage sg-stage--dark">
         <div class="sg-row">
-          <a class="btn btn--primary">Primary <span class="btn__ico" aria-hidden="true">→</span></a>
-          <a class="btn btn--gradient">Gradient <span class="btn__ico" aria-hidden="true">→</span></a>
-          <a class="btn btn--ghost">Ghost</a>
-          <a class="btn btn--outline-white">Outline white</a>
-          <a class="btn btn--white">White</a>
+          <a class="btn btn--primary" href="javascript:void(0)">Primary</a>
+          <a class="btn btn--gradient" href="javascript:void(0)">Gradient</a>
+          <a class="btn btn--ghost" href="javascript:void(0)">View packages</a>
+          <a class="btn btn--outline-white" href="javascript:void(0)">Outline</a>
+          <a class="btn btn--white" href="javascript:void(0)">On orange</a>
         </div>
       </div>
+    </div>
 
-      <div class="sg-subhead">Sizes (sm · md · lg)</div>
-      <div class="sg-panel">
+    <div class="sg-block">
+      <span class="sg-label">Nav button (compact)</span>
+      <div class="sg-stage sg-stage--dark">
+        <div class="sg-row"><a class="btn btn--nav" href="javascript:void(0)">Book a call</a></div>
+      </div>
+    </div>
+
+    <table class="sg-table">
+      <thead><tr><th>Class</th><th>Use</th></tr></thead>
+      <tbody>
+        <tr><td><code>.btn--primary</code></td><td>Main action — orange fill, flame glow on hover</td></tr>
+        <tr><td><code>.btn--gradient</code></td><td>Loud moments — flame orange→red <em>(new)</em></td></tr>
+        <tr><td><code>.btn--ghost</code></td><td>Secondary on dark (e.g. “View packages”)</td></tr>
+        <tr><td><code>.btn--outline-white</code></td><td>Tertiary on dark</td></tr>
+        <tr><td><code>.btn--white</code></td><td>On orange / CTA blocks</td></tr>
+        <tr><td><code>.btn--nav</code></td><td>Compact nav CTA (keeps small size)</td></tr>
+      </tbody>
+    </table>
+    <p class="sg-note">Wrap a trailing icon in <code>&lt;span class="btn__ico"&gt;</code> so it nudges on hover.</p>
+  </section>
+
+  <!-- ============ INSTALL AGENT ============ -->
+  <section class="sg-sec" id="install">
+    <p class="sg-kicker">06 — Install Agent</p>
+    <h2 class="sg-h2">Install Agent CTA <span style="font-size:14px; color:var(--orange); font-weight:700; letter-spacing:.06em; text-transform:uppercase; vertical-align:middle;">· new</span></h2>
+    <p class="sg-lead">The hero call-to-action. A bot with personality plus a built-in install animation: the flame gradient sweeps left→right, a percentage counts up, then it settles into “Agent installed ✓” and the bot bounces. <strong>Click a button below to play it.</strong></p>
+
+    <div class="sg-block">
+      <span class="sg-label">Hero pairing — primary + secondary</span>
+      <div class="sg-stage sg-stage--dark">
         <div class="sg-row">
-          <a class="btn btn--primary btn--sm">Small</a>
-          <a class="btn btn--primary">Medium</a>
-          <a class="btn btn--primary btn--lg">Large <span class="btn__ico" aria-hidden="true">→</span></a>
-        </div>
-        <p class="sg-note">Default (no size class) is medium: <span class="sg-code">19px 34px</span> padding. <span class="sg-code">.btn--sm</span> / <span class="sg-code">.btn--lg</span> adjust padding, font-size, and radius together.</p>
-      </div>
-
-      <div class="sg-subhead">Nav variant + disabled</div>
-      <div class="sg-panel sg-panel--dark">
-        <div class="sg-row">
-          <a class="btn btn--nav">Schedule a call</a>
-          <a class="btn btn--primary" aria-disabled="true">Disabled</a>
-        </div>
-        <p class="sg-note" style="color:#aaa;"><span class="sg-code">.btn--nav</span> is the compact CTA used in the sticky header. <span class="sg-code">[aria-disabled="true"]</span> dims to 45% and drops pointer events.</p>
-      </div>
-    </section>
-
-    <!-- ============================= CARDS ============================= -->
-    <section class="sg-section" id="cards">
-      <h2>Card — <span class="sg-code">.card</span></h2>
-      <p class="sg-lead">The workhorse surface. The orange <span class="sg-code">.agent__icon</span> tile wiggles on hover; link cards lift. <strong>Hover the cards below.</strong></p>
-
-      <div class="sg-subhead">Agent cards — icon wiggle on hover (<span class="sg-code">.card--agent</span>)</div>
-      <div class="sg-panel sg-panel--slate">
-        <div class="cards cards--2">
-          <div class="card card--agent">
-            <div class="agent__icon">
-              <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 2l1.8 5.2L18 9l-5.2 1.8L11 16l-1.8-5.2L4 9l5.2-1.8z" stroke="#ff7a00" stroke-width="1.8" stroke-linejoin="round"/></svg>
-            </div>
-            <h3>SEM Monitoring Agent</h3>
-            <p>Watches spend, flags anomalies, suggests optimizations across paid search.</p>
-          </div>
-          <div class="card card--agent">
-            <div class="agent__icon">
-              <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><rect x="3" y="11" width="3.4" height="8" rx="1" fill="#ff7a00"/><rect x="9.3" y="6" width="3.4" height="13" rx="1" fill="#ff7a00"/><rect x="15.6" y="9" width="3.4" height="10" rx="1" fill="#ff7a00"/></svg>
-            </div>
-            <h3>Reporting Agent</h3>
-            <p>Compiles clean, on-time performance reports your team can actually run.</p>
-          </div>
-        </div>
-      </div>
-
-      <div class="sg-subhead">Link card — lifts on hover (<span class="sg-code">.card--outline.card--link</span>)</div>
-      <div class="sg-panel sg-panel--slate">
-        <div class="cards cards--2">
-          <a href="#cards" class="card card--outline card--link">
-            <div class="card__body">
-              <p class="card__eyebrow">Resource</p>
-              <h3 class="card__title">How we build a first agent</h3>
-              <p class="card__excerpt">A look at the 4–6 week engagement, from discovery to handoff.</p>
-            </div>
-            <div class="card__footer">
-              <span class="card__readmore">Read more →</span>
-            </div>
-          </a>
-          <div class="card card--dark">
-            <h3>Dark card</h3>
-            <p><span class="sg-code" style="color:#fff;background:rgba(255,255,255,.1);">.card--dark</span> for cards placed on black sections. Body uses <em>--text-muted</em>; emphasis uses --yellow.</p>
-          </div>
-        </div>
-      </div>
-
-      <div class="sg-subhead">Package cards (<span class="sg-code">.card--package</span> / <span class="sg-code">.card--package-featured</span>) — on dark</div>
-      <div class="sg-panel sg-panel--dark">
-        <div class="cards cards--2">
-          <div class="card card--package">
-            <div class="card__number">01</div>
-            <h3>First Agent</h3>
-            <p style="color:var(--text-muted);font-size:15px;">One orchestrator with 4–6 skills for a single job.</p>
-          </div>
-          <div class="card card--package card--package-featured">
-            <div class="card__number">02</div>
-            <h3>Agent System</h3>
-            <p style="color:var(--text-muted);font-size:15px;">2–3 orchestrators across functions with cross-agent reporting.</p>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <!-- ============================= INSTALL AGENT ============================= -->
-    <section class="sg-section" id="install">
-      <h2>Install agent — <span class="sg-code">.ia2</span></h2>
-      <p class="sg-lead">
-        The hero "put an agent to work" CTA, with a personality bot and a built-in install animation.
-        <strong>Click any button to play it</strong> (idle → installing → done → reset). In production the
-        marketing page links to Stripe checkout; the post-payment setup page drives the states. Three
-        variants share one engine.
-      </p>
-
-      <div class="sg-subhead">dark (default, "Direction B") · solid · outline</div>
-      <div class="sg-panel sg-panel--dark">
-        <div class="sg-row" style="gap:20px;">
-          <button class="ia2 ia2--dark" data-install-agent data-label="Install agent" data-sublabel="Self-service guided setup" aria-live="polite">
-            <span class="ia2-fill"></span><span class="ia2-bot"></span>
+          <button class="ia2 ia2--dark" data-install-agent>
+            <span class="ia2-fill"></span>
+            <span class="ia2-bot"></span>
             <span class="ia2-label"><span class="ia2-main">Install agent</span><span class="ia2-sub">Self-service guided setup</span></span>
           </button>
-          <button class="ia2 ia2--solid" data-install-agent data-label="Install agent" data-sublabel="Self-service guided setup" aria-live="polite">
-            <span class="ia2-fill"></span><span class="ia2-bot"></span>
-            <span class="ia2-label"><span class="ia2-main">Install agent</span><span class="ia2-sub">Self-service guided setup</span></span>
-          </button>
-          <button class="ia2 ia2--outline" data-install-agent data-label="Install agent" data-sublabel="Self-service guided setup" aria-live="polite">
-            <span class="ia2-fill"></span><span class="ia2-bot"></span>
-            <span class="ia2-label"><span class="ia2-main">Install agent</span><span class="ia2-sub">Self-service guided setup</span></span>
-          </button>
+          <a class="btn btn--ghost" href="javascript:void(0)">View packages</a>
         </div>
-        <p class="sg-note" style="color:#aaa;">Paired in the hero with a <span class="sg-code" style="color:#fff;background:rgba(255,255,255,.1);">.btn--ghost</span> "View packages" secondary. Wiring the real Stripe checkout + controlled setup-page states is tracked in issue #25.</p>
+        <p class="sg-note" style="color:rgba(255,255,255,.5)">Direction B (default <code style="color:#ff9a4d">.ia2--dark</code>): black button, flame gradient fill.</p>
       </div>
-    </section>
+    </div>
 
-    <!-- ============================= METRIC NUMBERS ============================= -->
-    <section class="sg-section" id="metrics">
-      <h2>Gradient metric numbers — <span class="sg-code">.metric-card</span></h2>
-      <p class="sg-lead">Big <strong>Kamura</strong> (<span class="sg-code">--font-heading</span>) figures used on case studies (<span class="sg-code">/results/</span>) — the display serif's main job besides the wordmark. The flame gradient is clipped to the text via <span class="sg-code">background-clip: text</span>. Defined in <span class="sg-code">results.css</span>, laid out in a <span class="sg-code">.cs-metrics</span> grid.</p>
-      <div class="cs-metrics">
-        <div class="metric-card">
-          <div class="metric-card__value">95%</div>
-          <div class="metric-card__label">Match rate</div>
-          <div class="metric-card__detail">across 400+ enriched VC contacts</div>
-        </div>
-        <div class="metric-card">
-          <div class="metric-card__value">200h → 2h</div>
-          <div class="metric-card__label">Research time</div>
-          <div class="metric-card__detail">manual LinkedIn research, automated</div>
-        </div>
-        <div class="metric-card">
-          <div class="metric-card__value">8</div>
-          <div class="metric-card__label">Countries</div>
-          <div class="metric-card__detail">a discovery UX that scaled</div>
+    <div class="sg-block">
+      <span class="sg-label">Variants</span>
+      <div class="sg-stage sg-stage--dark">
+        <div class="sg-row">
+          <button class="ia2 ia2--solid" data-install-agent><span class="ia2-fill"></span><span class="ia2-bot"></span><span class="ia2-label"><span class="ia2-main">Install agent</span><span class="ia2-sub">Self-service guided setup</span></span></button>
+          <button class="ia2 ia2--outline" data-install-agent><span class="ia2-fill"></span><span class="ia2-bot"></span><span class="ia2-label"><span class="ia2-main">Install agent</span><span class="ia2-sub">Self-service guided setup</span></span></button>
         </div>
       </div>
-    </section>
+    </div>
 
-    <!-- ============================= RULES ============================= -->
-    <section class="sg-section" id="rules">
-      <h2>Rules &amp; conventions</h2>
-      <p class="sg-lead">Where the rules live and the constraints to respect when building new pages (e.g. the new self-service homepage).</p>
-      <ul class="sg-rules">
-        <li><strong>Tokens source of truth:</strong> the <code>:root</code> block in <code>styles.css</code>. Never introduce a new hex — add or reuse a token. The README brand-token table is outdated.</li>
-        <li><strong>CSS lives in three files by zone:</strong> <code>styles.css</code> (homepage + shared: buttons, cards, nav, hero, timeline, install agent), <code>results.css</code> (case studies — metric cards etc.), <code>blog.css</code> (blog posts).</li>
-        <li><strong>Class naming:</strong> the site uses plain BEM-ish names — <code>.btn</code>, <code>.card</code>, <code>.agent__icon</code>, <code>.card--link</code>. The design-system handoff ships <code>--es-*</code> tokens and <code>.es-btn</code>/<code>.es-card</code>; those must be remapped to the names above when applied here (see issue #27 to end this drift).</li>
-        <li><strong>Nav &amp; footer exist in three places</strong> — <code>index.html</code>, <code>_layouts/post.html</code>, <code>resources/index.html</code>. Change all three together.</li>
-        <li><strong>Case studies are not Jekyll</strong> — <code>results/*</code> and this page are hand-built static HTML (no Liquid, no front matter).</li>
-        <li><strong>Fonts use root-relative <code>@font-face</code> paths</strong> (<code>/fonts/…</code>) so they load from sub-pages like <code>/styleguide/</code> and <code>/results/slug/</code>.</li>
-        <li><strong>Motion honors <code>prefers-reduced-motion</code></strong> — every hover lift, wiggle, and the install sweep are disabled under it. Match that for new motion.</li>
-        <li><strong>Mobile integrity</strong> is gated by the Huginn Playwright suite (no horizontal overflow at iPhone SE width). Keep new components within the viewport.</li>
-        <li><strong>Open follow-ups:</strong> #25 (Stripe checkout + setup-page states), #26 (self-service homepage repositioning), #27 (source tokens/components from the shared design system).</li>
-      </ul>
-    </section>
+    <div class="sg-block">
+      <span class="sg-label">States (driven via the JS API)</span>
+      <div class="sg-stage sg-stage--dark">
+        <div class="sg-row" style="gap:18px">
+          <button class="ia2 ia2--dark" id="sg-state-idle"><span class="ia2-fill"></span><span class="ia2-bot"></span><span class="ia2-label"><span class="ia2-main">Install agent</span><span class="ia2-sub">Self-service guided setup</span></span></button>
+          <button class="ia2 ia2--dark" id="sg-state-installing"><span class="ia2-fill"></span><span class="ia2-bot"></span><span class="ia2-label"><span class="ia2-main">Install agent</span><span class="ia2-sub">Self-service guided setup</span></span></button>
+          <button class="ia2 ia2--dark" id="sg-state-done"><span class="ia2-fill"></span><span class="ia2-bot"></span><span class="ia2-label"><span class="ia2-main">Install agent</span><span class="ia2-sub">Self-service guided setup</span></span></button>
+        </div>
+        <p class="sg-note" style="color:rgba(255,255,255,.5)">idle · installing (frozen mid-sweep) · done</p>
+      </div>
+    </div>
 
-  </div>
+    <table class="sg-table">
+      <thead><tr><th>State</th><th>Main</th><th>Sub</th></tr></thead>
+      <tbody>
+        <tr><td>idle</td><td>Install agent</td><td>Self-service guided setup</td></tr>
+        <tr><td>installing</td><td>Installing…</td><td>Provisioning your agent</td></tr>
+        <tr><td>done</td><td>Agent installed</td><td>Setup complete</td></tr>
+      </tbody>
+    </table>
 
-  <!-- bot SVG, cloned into every .ia2-bot, then the component self-mounts -->
-  <template id="ia2bot-tmpl">
-    <span class="ia2bot">
-      <svg width="36" height="36" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="install agent">
-        <g class="ia2bot-all">
-          <line x1="24" y1="12" x2="24" y2="6.5" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/>
-          <g transform="translate(24 3)"><g class="ia2bot-tip">
-            <path d="M0 -3.4 L1 -1 L3.4 0 L1 1 L0 3.4 L-1 1 L-3.4 0 L-1 -1 Z" fill="currentColor"/>
-          </g></g>
-          <rect x="5.6" y="20" width="3" height="9" rx="1.5" fill="currentColor"/>
-          <rect x="39.4" y="20" width="3" height="9" rx="1.5" fill="currentColor"/>
-          <rect x="9" y="12" width="30" height="26" rx="8.5" fill="none" stroke="currentColor" stroke-width="2.4"/>
-          <g class="ia2bot-look">
-            <g class="ia2bot-eyes">
-              <circle cx="18" cy="24" r="2.7" fill="currentColor"/>
-              <circle cx="30" cy="24" r="2.7" fill="currentColor"/>
-            </g>
-            <path d="M19.5 30.6 Q24 34 28.5 30.6" stroke="currentColor" stroke-width="1.9" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
-          </g>
-          <g class="ia2bot-check" transform="translate(34 33)">
-            <circle r="6.4" fill="currentColor"/>
-            <path d="M-3 0.2 L-0.8 2.4 L3.2 -2.2" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
-          </g>
-        </g>
-      </svg>
-    </span>
-  </template>
-  <script>
-    (function () {
-      var tmpl = document.getElementById('ia2bot-tmpl');
-      document.querySelectorAll('.ia2 .ia2-bot').forEach(function (slot) {
-        slot.appendChild(tmpl.content.cloneNode(true));
-      });
-    })();
-  </script>
-  <script src="/assets/install-agent.js" defer></script>
+    <div class="sg-pre"><span class="c">&lt;!-- Hero: opens Stripe on click (no animation) --&gt;</span>
+&lt;a class=<span class="k">"ia2 ia2--dark"</span> data-install-agent data-href href=<span class="k">"…stripe…"</span>&gt;…&lt;/a&gt;
+
+<span class="c">// Setup page (post-payment): drive it from your code</span>
+EldurInstallAgent.setState(el, <span class="k">'installing'</span>); <span class="c">// provisioning</span>
+EldurInstallAgent.setState(el, <span class="k">'done'</span>);       <span class="c">// guided setup complete</span></div>
+    <p class="sg-note">Real flow: <strong>hero = Stripe link</strong> → checkout → on success route to the setup page, which renders the <em>controlled</em> button and calls <code>setState('installing')</code> then <code>setState('done')</code>. A plain <code>&lt;button data-install-agent&gt;</code> with no <code>data-href</code>/<code>data-controlled</code> self-demos on click. Honors <code>prefers-reduced-motion</code>.</p>
+  </section>
+
+  <!-- ============ CARDS ============ -->
+  <section class="sg-sec" id="cards">
+    <p class="sg-kicker">07 — Cards</p>
+    <h2 class="sg-h2">Cards</h2>
+    <p class="sg-lead">Calm at rest. White (or <code class="sg-code">--dark</code> on black sections) with a hairline border and 20px radius. On hover the border turns orange; link cards now also lift.</p>
+    <div class="sg-block">
+      <span class="sg-label">outline · dark</span>
+      <div class="cards cards--2">
+        <div class="card card--outline"><p><strong>Outline card.</strong> The default content surface — hairline border, white fill, generous 32px padding.</p></div>
+        <div class="card card--dark"><h3>Dark card</h3><p>For black sections. Muted body, <em>yellow</em> emphasis when needed.</p></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ AGENT CARDS ============ -->
+  <section class="sg-sec" id="agent">
+    <p class="sg-kicker">08 — Agent Cards</p>
+    <h2 class="sg-h2">Agent cards <span style="font-size:14px; color:var(--orange); font-weight:700; letter-spacing:.06em; text-transform:uppercase; vertical-align:middle;">· updated</span></h2>
+    <p class="sg-lead">The icon tile now does the agent-bot <strong>wiggle on hover</strong> and the card lifts — the one sanctioned bit of personality, carried over from the Install Agent bot. <strong>Hover a card.</strong></p>
+    <div class="sg-stage sg-stage--light">
+      <div class="cards cards--3" id="agent-cards"></div>
+    </div>
+  </section>
+
+  <!-- ============ PACKAGES ============ -->
+  <section class="sg-sec" id="packages">
+    <p class="sg-kicker">09 — Packages</p>
+    <h2 class="sg-h2">Pricing tiers</h2>
+    <p class="sg-lead">Package cards live on black. The featured tier swaps to an orange border over a warm tint.</p>
+    <div class="sg-stage sg-stage--dark">
+      <div class="cards cards--2">
+        <div class="card card--package">
+          <div class="card__number">01</div>
+          <h3>Single Agent</h3>
+          <div class="card__tag">2–3 weeks</div>
+          <ul><li>One agent, fully installed</li><li>Monitored + reporting</li><li>30-day tuning window</li></ul>
+        </div>
+        <div class="card card--package card--package-featured">
+          <div class="card__number">02</div>
+          <h3>Agent System</h3>
+          <div class="card__tag">Most popular</div>
+          <ul><li>2–3 orchestrated agents</li><li>Cross-agent reporting</li><li>Quarterly optimization</li></ul>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ BITS ============ -->
+  <section class="sg-sec" id="bits">
+    <p class="sg-kicker">10 — Eyebrows · Chips · Highlight</p>
+    <h2 class="sg-h2">Small components</h2>
+    <div class="sg-block">
+      <span class="sg-label">Eyebrow</span>
+      <div class="sg-stage sg-stage--light"><span class="eyebrow">How it works</span></div>
+    </div>
+    <div class="sg-block">
+      <span class="sg-label">Chip (with left accent)</span>
+      <div class="sg-stage sg-stage--light">
+        <div style="display:grid; grid-template-columns:repeat(auto-fit, minmax(220px, 1fr)); gap:12px;">
+          <div class="chip"><strong>Auditable.</strong>&nbsp;Every decision the agent makes is logged.</div>
+          <div class="chip"><strong>Installed.</strong>&nbsp;Runs in your stack, not a dashboard.</div>
+        </div>
+      </div>
+    </div>
+    <div class="sg-block">
+      <span class="sg-label">Highlight callout</span>
+      <div class="highlight" style="margin-top:0">Agents don’t replace your team — they take the work no one had time for.</div>
+    </div>
+  </section>
+
+  <!-- ============ TIMELINE ============ -->
+  <section class="sg-sec" id="timeline">
+    <p class="sg-kicker">11 — Timeline</p>
+    <h2 class="sg-h2">Process timeline</h2>
+    <div class="sg-stage sg-stage--light">
+      <div class="timeline">
+        <div class="timeline__step"><div class="timeline__dot"></div><div class="timeline__week">Week 1</div><div class="timeline__label">Map</div><div class="timeline__desc">We find the highest-leverage agent for your funnel.</div></div>
+        <div class="timeline__step"><div class="timeline__dot"></div><div class="timeline__week">Week 2–3</div><div class="timeline__label">Build</div><div class="timeline__desc">Designed, built, and tested against your real data.</div></div>
+        <div class="timeline__step"><div class="timeline__dot"></div><div class="timeline__week">Week 4</div><div class="timeline__label">Install</div><div class="timeline__desc">Live in your stack, monitored and reporting.</div></div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ============ FAQ ============ -->
+  <section class="sg-sec" id="faq">
+    <p class="sg-kicker">12 — FAQ</p>
+    <h2 class="sg-h2">FAQ (native accordion)</h2>
+    <div class="sg-stage" style="background:#fff">
+      <div class="faq">
+        <details class="faq__item" open><summary class="faq__q">How long until an agent is live?</summary><div class="faq__a"><p>Most single agents are installed within 2–3 weeks, including a tuning window against your real data.</p></div></details>
+        <details class="faq__item"><summary class="faq__q">Does it run in our stack?</summary><div class="faq__a"><p>Yes — agents are installed into your tools and workflows, not a separate dashboard you have to babysit.</p></div></details>
+      </div>
+    </div>
+  </section>
+
+</div>
+
+<script src="/assets/install-agent.js"></script>
+<script>
+  // ---- color swatches ----
+  var COLORS = [
+    ['--black','#000000'],['--dark','#111111'],['--orange','#ff7a00'],['--red','#ee0f0f'],
+    ['--yellow','#ffc109'],['--white','#FFFFFF'],['--gray','#EFEFF1'],['--orange-dim','rgba(255,122,0,.08)']
+  ];
+  document.getElementById('swatches').innerHTML = COLORS.map(function(c){
+    var border = (c[0]==='--white'||c[0]==='--gray'||c[0]==='--orange-dim') ? 'border-bottom:1px solid var(--border)' : '';
+    return '<div class="sg-sw"><div class="sg-sw__chip" style="background:'+c[1]+';'+border+'"></div>'
+      + '<div class="sg-sw__meta"><div class="sg-sw__name">'+c[0]+'</div><div class="sg-sw__val">'+c[1]+'</div></div></div>';
+  }).join('');
+
+  // ---- agent cards (icon tile wiggles on hover) ----
+  var AGENTS = [
+    ['SEM Monitoring','Watches spend &amp; performance, flags anomalies, suggests optimizations.'],
+    ['Intake &amp; Qualify','Routes, enriches and classifies inbound leads with an auditable trail.'],
+    ['Reporting','Compiles clean, on-time performance reports your team can run.']
+  ];
+  var AICON = '<svg width="22" height="22" viewBox="0 0 22 22" fill="none"><rect x="2.5" y="4" width="17" height="13" rx="4" stroke="#ff7a00" stroke-width="2"/><circle cx="8" cy="10.5" r="1.4" fill="#ff7a00"/><circle cx="14" cy="10.5" r="1.4" fill="#ff7a00"/><path d="M11 4V1.6M11 1.6a1.3 1.3 0 1 0 0-.01" stroke="#ff7a00" stroke-width="2" stroke-linecap="round"/></svg>';
+  document.getElementById('agent-cards').innerHTML = AGENTS.map(function(a){
+    return '<div class="card card--agent"><div class="agent__icon">'+AICON+'</div><h3>'+a[0]+'</h3><p>'+a[1]+'</p></div>';
+  }).join('');
+
+  // ---- inject the bot SVG into every .ia2-bot ----
+  var BOT = '<span class="ia2bot"><svg width="36" height="36" viewBox="0 0 48 48" fill="none" role="img" aria-label="install agent"><g class="ia2bot-all"><line x1="24" y1="12" x2="24" y2="6.5" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/><g transform="translate(24 3)"><g class="ia2bot-tip"><path d="M0 -3.4 L1 -1 L3.4 0 L1 1 L0 3.4 L-1 1 L-3.4 0 L-1 -1 Z" fill="currentColor"/></g></g><rect x="5.6" y="20" width="3" height="9" rx="1.5" fill="currentColor"/><rect x="39.4" y="20" width="3" height="9" rx="1.5" fill="currentColor"/><rect x="9" y="12" width="30" height="26" rx="8.5" fill="none" stroke="currentColor" stroke-width="2.4"/><g class="ia2bot-look"><g class="ia2bot-eyes"><circle cx="18" cy="24" r="2.7" fill="currentColor"/><circle cx="30" cy="24" r="2.7" fill="currentColor"/></g><path d="M19.5 30.6 Q24 34 28.5 30.6" stroke="currentColor" stroke-width="1.9" fill="none" stroke-linecap="round" stroke-linejoin="round"/></g><g class="ia2bot-check" transform="translate(34 33)"><circle r="6.4" fill="currentColor"/><path d="M-3 0.2 L-0.8 2.4 L3.2 -2.2" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></g></g></svg></span>';
+  document.querySelectorAll('.ia2-bot').forEach(function(s){ s.innerHTML = BOT; });
+
+  // (re)mount install-agent behavior now that bots exist
+  if (window.EldurInstallAgent) window.EldurInstallAgent.init();
+
+  // ---- pin the three state demos ----
+  window.addEventListener('load', function(){
+    var EA = window.EldurInstallAgent; if (!EA) return;
+    var installing = document.getElementById('sg-state-installing');
+    var done = document.getElementById('sg-state-done');
+    // freeze "installing" as a clean static specimen at 60%
+    if (installing) {
+      installing._controlled = true;
+      installing.classList.add('is-installing');
+      installing.querySelector('.ia2-main').textContent = 'Installing…';
+      installing.querySelector('.ia2-sub').textContent = 'Provisioning your agent';
+      installing.querySelector('.ia2bot').classList.add('ia2bot--working');
+      var f = installing.querySelector('.ia2-fill');
+      f.style.transition = 'none'; f.style.transform = 'scaleX(0.6)';
+      var pct = document.createElement('span'); pct.className = 'ia2-pct'; pct.textContent = '60%';
+      installing.appendChild(pct);
+    }
+    if (done) { done._controlled = true; EA.setState(done, 'done'); }
+  });
+</script>
 </body>
 </html>

--- a/styleguide/index.html
+++ b/styleguide/index.html
@@ -104,7 +104,7 @@ layout: null
     <a href="#cards">Cards</a>
     <a href="#agent">Agent Cards</a>
     <a href="#packages">Packages</a>
-    <a href="#bits">Eyebrows · Chips · Highlight</a>
+    <a href="#bits">Chips · Highlight</a>
     <a href="#timeline">Timeline</a>
     <a href="#faq">FAQ</a>
   </nav>
@@ -159,10 +159,6 @@ layout: null
       <div class="sg-type__row">
         <div class="sg-type__meta">Body<br>Basier 400<br>16px / 1.65</div>
         <div style="font-size:16px; line-height:1.65; color:#333; max-width:560px;">The workhorse paragraph size. Used in cards, FAQ answers, and long-form copy across the site. Readable, unhurried, never cramped.</div>
-      </div>
-      <div class="sg-type__row">
-        <div class="sg-type__meta">Eyebrow<br>Basier 700<br>12px · 0.12em</div>
-        <div><span class="eyebrow">How it works</span></div>
       </div>
     </div>
   </section>
@@ -373,12 +369,8 @@ EldurInstallAgent.setState(el, <span class="k">'done'</span>);       <span class
 
   <!-- ============ BITS ============ -->
   <section class="sg-sec" id="bits">
-    <p class="sg-kicker">10 — Eyebrows · Chips · Highlight</p>
+    <p class="sg-kicker">10 — Chips · Highlight</p>
     <h2 class="sg-h2">Small components</h2>
-    <div class="sg-block">
-      <span class="sg-label">Eyebrow</span>
-      <div class="sg-stage sg-stage--light"><span class="eyebrow">How it works</span></div>
-    </div>
     <div class="sg-block">
       <span class="sg-label">Chip (with left accent)</span>
       <div class="sg-stage sg-stage--light">

--- a/styleguide/index.html
+++ b/styleguide/index.html
@@ -1,0 +1,324 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex, nofollow">
+  <title>Eldur Studio — Style Guide</title>
+  <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
+
+  <!-- The real site CSS. This page renders live components straight from
+       these files, so it can never drift from production. Root-relative
+       paths resolve both on eldur.studio and at /styleguide/ locally. -->
+  <link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/results.css">
+
+  <style>
+    /* ----- Page-local layout only (prefixed `sg-`, no brand tokens defined here) ----- */
+    body.sg { font-size: 16px; background: var(--white); color: var(--black); }
+    .sg-wrap { max-width: 1100px; margin: 0 auto; padding: 48px 32px 96px; }
+    .sg-header { border-bottom: 1px solid var(--border); padding-bottom: 28px; margin-bottom: 48px; }
+    .sg-header h1 { font-family: var(--font-heading); font-size: clamp(34px, 5vw, 52px); line-height: 1.05; letter-spacing: -0.02em; margin-bottom: 14px; }
+    .sg-header p { font-size: 17px; line-height: 1.6; color: #444; max-width: 680px; }
+    .sg-toc { display: flex; flex-wrap: wrap; gap: 10px 18px; margin-top: 22px; font-size: 14px; }
+    .sg-toc a { color: var(--orange); text-decoration: none; font-weight: 600; }
+    .sg-toc a:hover { text-decoration: underline; }
+
+    .sg-section { margin-bottom: 64px; scroll-margin-top: 24px; }
+    .sg-section > h2 { font-family: var(--font-heading); font-size: 28px; letter-spacing: -0.01em; margin-bottom: 6px; }
+    .sg-section > .sg-lead { color: #555; font-size: 15px; line-height: 1.6; margin-bottom: 24px; max-width: 720px; }
+    .sg-subhead { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.08em; color: #888; margin: 28px 0 14px; }
+
+    /* a labelled demo panel — `dark` for components that live on black sections */
+    .sg-panel { border: 1.5px solid var(--border); border-radius: var(--radius-lg); padding: 28px; background: var(--white); }
+    .sg-panel--dark { background: var(--black); border-color: rgba(255,255,255,0.12); }
+    .sg-panel--slate { background: var(--gray); }
+    .sg-row { display: flex; flex-wrap: wrap; gap: 16px; align-items: center; }
+    .sg-stack { display: flex; flex-direction: column; gap: 14px; align-items: flex-start; }
+
+    /* token: color swatches */
+    .sg-swatches { display: grid; grid-template-columns: repeat(auto-fill, minmax(150px, 1fr)); gap: 14px; }
+    .sg-swatch { border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
+    .sg-swatch__chip { height: 72px; }
+    .sg-swatch__meta { padding: 10px 12px; font-size: 12px; line-height: 1.5; }
+    .sg-swatch__meta code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px; color: #333; }
+    .sg-swatch__meta b { display: block; font-size: 13px; }
+
+    /* token: radii + type samples */
+    .sg-radii { display: flex; gap: 18px; flex-wrap: wrap; }
+    .sg-radius { width: 120px; height: 80px; background: var(--orange-dim); border: 1.5px solid var(--orange); display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 600; color: var(--orange); }
+
+    .sg-code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12.5px; background: #f4f4f5; border: 1px solid var(--border); border-radius: 8px; padding: 2px 7px; color: #b3360b; white-space: nowrap; }
+    .sg-note { font-size: 13px; color: #777; margin-top: 10px; line-height: 1.6; }
+    .sg-rules { font-size: 15px; line-height: 1.75; color: #333; }
+    .sg-rules li { margin-bottom: 10px; }
+    .sg-rules code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 13px; background: #f4f4f5; padding: 1px 6px; border-radius: 5px; color: #b3360b; }
+  </style>
+</head>
+<body class="sg">
+  <div class="sg-wrap">
+
+    <header class="sg-header">
+      <h1>Eldur Studio — Style Guide</h1>
+      <p>
+        The living catalog of brand tokens and components, rendered straight from the
+        production CSS (<span class="sg-code">styles.css</span> + <span class="sg-code">results.css</span>) — so it
+        can't drift from the real site. This is the visual reference that used to live only in the
+        design-system project's <span class="sg-code">visual-reference/exploration.html</span>.
+        <strong>Source of truth for all tokens is the <span class="sg-code">:root</span> block in
+        <span class="sg-code">styles.css</span></strong> (the README brand-token table is outdated).
+      </p>
+      <nav class="sg-toc">
+        <a href="#tokens">Tokens</a>
+        <a href="#buttons">Buttons</a>
+        <a href="#cards">Cards</a>
+        <a href="#install">Install agent</a>
+        <a href="#metrics">Metric numbers</a>
+        <a href="#rules">Rules &amp; conventions</a>
+      </nav>
+    </header>
+
+    <!-- ============================= TOKENS ============================= -->
+    <section class="sg-section" id="tokens">
+      <h2>Design tokens</h2>
+      <p class="sg-lead">CSS custom properties defined in <span class="sg-code">styles.css :root</span>. Use the token, never a raw hex.</p>
+
+      <div class="sg-subhead">Color</div>
+      <div class="sg-swatches">
+        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:#000000"></div><div class="sg-swatch__meta"><b>--black</b><code>#000000</code></div></div>
+        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:#111111"></div><div class="sg-swatch__meta"><b>--dark</b><code>#111111</code></div></div>
+        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:#ff7a00"></div><div class="sg-swatch__meta"><b>--orange</b><code>#ff7a00</code></div></div>
+        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:#ff7a00;opacity:.08"></div><div class="sg-swatch__meta"><b>--orange-dim</b><code>rgba(255,122,0,.08)</code></div></div>
+        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:#ee0f0f"></div><div class="sg-swatch__meta"><b>--red</b><code>#ee0f0f</code></div></div>
+        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:#ffc109"></div><div class="sg-swatch__meta"><b>--yellow</b><code>#ffc109</code></div></div>
+        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:linear-gradient(90deg,#ff7a00 0%,#ee0f0f 100%)"></div><div class="sg-swatch__meta"><b>--gradient</b><code>orange → red, 90deg</code></div></div>
+        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:#FFFFFF;border-bottom:1px solid var(--border)"></div><div class="sg-swatch__meta"><b>--white</b><code>#FFFFFF</code></div></div>
+        <div class="sg-swatch"><div class="sg-swatch__chip" style="background:#EFEFF1"></div><div class="sg-swatch__meta"><b>--gray</b><code>#EFEFF1</code></div></div>
+      </div>
+      <p class="sg-note">On dark sections, body text uses <span class="sg-code">--text-muted</span> (<code>rgba(255,255,255,.65)</code>); hairline dividers use <span class="sg-code">--border</span> (<code>rgba(0,0,0,.10)</code>).</p>
+
+      <div class="sg-subhead">Type</div>
+      <div class="sg-panel">
+        <p style="font-family:var(--font-heading);font-size:40px;line-height:1.05;letter-spacing:-0.02em;margin-bottom:18px;">Kamura — display / headlines</p>
+        <p style="font-family:var(--font);font-size:24px;font-weight:700;margin-bottom:4px;">Basier Circle Bold 700 — H-level UI</p>
+        <p style="font-family:var(--font);font-size:17px;font-weight:600;margin-bottom:4px;">Basier Circle SemiBold 600 — buttons, labels</p>
+        <p style="font-family:var(--font);font-size:16px;font-weight:400;color:#444;">Basier Circle Regular 400 — body copy. The quick brown fox jumps over the lazy dog.</p>
+        <p class="sg-note"><span class="sg-code">--font-heading</span> = Kamura (serif display) · <span class="sg-code">--font</span> = Basier Circle (weights 400/500/600/700). Fonts load via root-relative <span class="sg-code">@font-face</span> paths so they work from sub-pages.</p>
+      </div>
+
+      <div class="sg-subhead">Radius</div>
+      <div class="sg-radii">
+        <div class="sg-radius" style="border-radius:12px">--radius · 12px</div>
+        <div class="sg-radius" style="border-radius:20px">--radius-lg · 20px</div>
+        <div class="sg-radius" style="border-radius:100px">pill · 100px</div>
+      </div>
+    </section>
+
+    <!-- ============================= BUTTONS ============================= -->
+    <section class="sg-section" id="buttons">
+      <h2>Button — <span class="sg-code">.btn</span></h2>
+      <p class="sg-lead">A confident 12px rounded rectangle (was a 100px pill): 17px/700 type, a hover micro-lift + flame glow, and a trailing icon that nudges. Wrap icons in <span class="sg-code">.btn__ico</span> so they animate.</p>
+
+      <div class="sg-subhead">Variants on dark (ghost / outline-white / white are for dark sections)</div>
+      <div class="sg-panel sg-panel--dark">
+        <div class="sg-row">
+          <a class="btn btn--primary">Primary <span class="btn__ico" aria-hidden="true">→</span></a>
+          <a class="btn btn--gradient">Gradient <span class="btn__ico" aria-hidden="true">→</span></a>
+          <a class="btn btn--ghost">Ghost</a>
+          <a class="btn btn--outline-white">Outline white</a>
+          <a class="btn btn--white">White</a>
+        </div>
+      </div>
+
+      <div class="sg-subhead">Sizes (sm · md · lg)</div>
+      <div class="sg-panel">
+        <div class="sg-row">
+          <a class="btn btn--primary btn--sm">Small</a>
+          <a class="btn btn--primary">Medium</a>
+          <a class="btn btn--primary btn--lg">Large <span class="btn__ico" aria-hidden="true">→</span></a>
+        </div>
+        <p class="sg-note">Default (no size class) is medium: <span class="sg-code">19px 34px</span> padding. <span class="sg-code">.btn--sm</span> / <span class="sg-code">.btn--lg</span> adjust padding, font-size, and radius together.</p>
+      </div>
+
+      <div class="sg-subhead">Nav variant + disabled</div>
+      <div class="sg-panel sg-panel--dark">
+        <div class="sg-row">
+          <a class="btn btn--nav">Schedule a call</a>
+          <a class="btn btn--primary" aria-disabled="true">Disabled</a>
+        </div>
+        <p class="sg-note" style="color:#aaa;"><span class="sg-code">.btn--nav</span> is the compact CTA used in the sticky header. <span class="sg-code">[aria-disabled="true"]</span> dims to 45% and drops pointer events.</p>
+      </div>
+    </section>
+
+    <!-- ============================= CARDS ============================= -->
+    <section class="sg-section" id="cards">
+      <h2>Card — <span class="sg-code">.card</span></h2>
+      <p class="sg-lead">The workhorse surface. The orange <span class="sg-code">.agent__icon</span> tile wiggles on hover; link cards lift. <strong>Hover the cards below.</strong></p>
+
+      <div class="sg-subhead">Agent cards — icon wiggle on hover (<span class="sg-code">.card--agent</span>)</div>
+      <div class="sg-panel sg-panel--slate">
+        <div class="cards cards--2">
+          <div class="card card--agent">
+            <div class="agent__icon">
+              <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M11 2l1.8 5.2L18 9l-5.2 1.8L11 16l-1.8-5.2L4 9l5.2-1.8z" stroke="#ff7a00" stroke-width="1.8" stroke-linejoin="round"/></svg>
+            </div>
+            <h3>SEM Monitoring Agent</h3>
+            <p>Watches spend, flags anomalies, suggests optimizations across paid search.</p>
+          </div>
+          <div class="card card--agent">
+            <div class="agent__icon">
+              <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><rect x="3" y="11" width="3.4" height="8" rx="1" fill="#ff7a00"/><rect x="9.3" y="6" width="3.4" height="13" rx="1" fill="#ff7a00"/><rect x="15.6" y="9" width="3.4" height="10" rx="1" fill="#ff7a00"/></svg>
+            </div>
+            <h3>Reporting Agent</h3>
+            <p>Compiles clean, on-time performance reports your team can actually run.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="sg-subhead">Link card — lifts on hover (<span class="sg-code">.card--outline.card--link</span>)</div>
+      <div class="sg-panel sg-panel--slate">
+        <div class="cards cards--2">
+          <a href="#cards" class="card card--outline card--link">
+            <div class="card__body">
+              <p class="card__eyebrow">Resource</p>
+              <h3 class="card__title">How we build a first agent</h3>
+              <p class="card__excerpt">A look at the 4–6 week engagement, from discovery to handoff.</p>
+            </div>
+            <div class="card__footer">
+              <span class="card__readmore">Read more →</span>
+            </div>
+          </a>
+          <div class="card card--dark">
+            <h3>Dark card</h3>
+            <p><span class="sg-code" style="color:#fff;background:rgba(255,255,255,.1);">.card--dark</span> for cards placed on black sections. Body uses <em>--text-muted</em>; emphasis uses --yellow.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="sg-subhead">Package cards (<span class="sg-code">.card--package</span> / <span class="sg-code">.card--package-featured</span>) — on dark</div>
+      <div class="sg-panel sg-panel--dark">
+        <div class="cards cards--2">
+          <div class="card card--package">
+            <div class="card__number">01</div>
+            <h3>First Agent</h3>
+            <p style="color:var(--text-muted);font-size:15px;">One orchestrator with 4–6 skills for a single job.</p>
+          </div>
+          <div class="card card--package card--package-featured">
+            <div class="card__number">02</div>
+            <h3>Agent System</h3>
+            <p style="color:var(--text-muted);font-size:15px;">2–3 orchestrators across functions with cross-agent reporting.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================= INSTALL AGENT ============================= -->
+    <section class="sg-section" id="install">
+      <h2>Install agent — <span class="sg-code">.ia2</span></h2>
+      <p class="sg-lead">
+        The hero "put an agent to work" CTA, with a personality bot and a built-in install animation.
+        <strong>Click any button to play it</strong> (idle → installing → done → reset). In production the
+        marketing page links to Stripe checkout; the post-payment setup page drives the states. Three
+        variants share one engine.
+      </p>
+
+      <div class="sg-subhead">dark (default, "Direction B") · solid · outline</div>
+      <div class="sg-panel sg-panel--dark">
+        <div class="sg-row" style="gap:20px;">
+          <button class="ia2 ia2--dark" data-install-agent data-label="Install agent" data-sublabel="Self-service guided setup" aria-live="polite">
+            <span class="ia2-fill"></span><span class="ia2-bot"></span>
+            <span class="ia2-label"><span class="ia2-main">Install agent</span><span class="ia2-sub">Self-service guided setup</span></span>
+          </button>
+          <button class="ia2 ia2--solid" data-install-agent data-label="Install agent" data-sublabel="Self-service guided setup" aria-live="polite">
+            <span class="ia2-fill"></span><span class="ia2-bot"></span>
+            <span class="ia2-label"><span class="ia2-main">Install agent</span><span class="ia2-sub">Self-service guided setup</span></span>
+          </button>
+          <button class="ia2 ia2--outline" data-install-agent data-label="Install agent" data-sublabel="Self-service guided setup" aria-live="polite">
+            <span class="ia2-fill"></span><span class="ia2-bot"></span>
+            <span class="ia2-label"><span class="ia2-main">Install agent</span><span class="ia2-sub">Self-service guided setup</span></span>
+          </button>
+        </div>
+        <p class="sg-note" style="color:#aaa;">Paired in the hero with a <span class="sg-code" style="color:#fff;background:rgba(255,255,255,.1);">.btn--ghost</span> "View packages" secondary. Wiring the real Stripe checkout + controlled setup-page states is tracked in issue #25.</p>
+      </div>
+    </section>
+
+    <!-- ============================= METRIC NUMBERS ============================= -->
+    <section class="sg-section" id="metrics">
+      <h2>Gradient metric numbers — <span class="sg-code">.metric-card</span></h2>
+      <p class="sg-lead">Big gradient-filled figures used on case studies (<span class="sg-code">/results/</span>). The flame gradient is clipped to the text via <span class="sg-code">background-clip: text</span>. Defined in <span class="sg-code">results.css</span>, laid out in a <span class="sg-code">.cs-metrics</span> grid.</p>
+      <div class="cs-metrics">
+        <div class="metric-card">
+          <div class="metric-card__value">95%</div>
+          <div class="metric-card__label">Match rate</div>
+          <div class="metric-card__detail">across 400+ enriched VC contacts</div>
+        </div>
+        <div class="metric-card">
+          <div class="metric-card__value">200h → 2h</div>
+          <div class="metric-card__label">Research time</div>
+          <div class="metric-card__detail">manual LinkedIn research, automated</div>
+        </div>
+        <div class="metric-card">
+          <div class="metric-card__value">8</div>
+          <div class="metric-card__label">Countries</div>
+          <div class="metric-card__detail">a discovery UX that scaled</div>
+        </div>
+      </div>
+    </section>
+
+    <!-- ============================= RULES ============================= -->
+    <section class="sg-section" id="rules">
+      <h2>Rules &amp; conventions</h2>
+      <p class="sg-lead">Where the rules live and the constraints to respect when building new pages (e.g. the new self-service homepage).</p>
+      <ul class="sg-rules">
+        <li><strong>Tokens source of truth:</strong> the <code>:root</code> block in <code>styles.css</code>. Never introduce a new hex — add or reuse a token. The README brand-token table is outdated.</li>
+        <li><strong>CSS lives in three files by zone:</strong> <code>styles.css</code> (homepage + shared: buttons, cards, nav, hero, timeline, install agent), <code>results.css</code> (case studies — metric cards etc.), <code>blog.css</code> (blog posts).</li>
+        <li><strong>Class naming:</strong> the site uses plain BEM-ish names — <code>.btn</code>, <code>.card</code>, <code>.agent__icon</code>, <code>.card--link</code>. The design-system handoff ships <code>--es-*</code> tokens and <code>.es-btn</code>/<code>.es-card</code>; those must be remapped to the names above when applied here (see issue #27 to end this drift).</li>
+        <li><strong>Nav &amp; footer exist in three places</strong> — <code>index.html</code>, <code>_layouts/post.html</code>, <code>resources/index.html</code>. Change all three together.</li>
+        <li><strong>Case studies are not Jekyll</strong> — <code>results/*</code> and this page are hand-built static HTML (no Liquid, no front matter).</li>
+        <li><strong>Fonts use root-relative <code>@font-face</code> paths</strong> (<code>/fonts/…</code>) so they load from sub-pages like <code>/styleguide/</code> and <code>/results/slug/</code>.</li>
+        <li><strong>Motion honors <code>prefers-reduced-motion</code></strong> — every hover lift, wiggle, and the install sweep are disabled under it. Match that for new motion.</li>
+        <li><strong>Mobile integrity</strong> is gated by the Huginn Playwright suite (no horizontal overflow at iPhone SE width). Keep new components within the viewport.</li>
+        <li><strong>Open follow-ups:</strong> #25 (Stripe checkout + setup-page states), #26 (self-service homepage repositioning), #27 (source tokens/components from the shared design system).</li>
+      </ul>
+    </section>
+
+  </div>
+
+  <!-- bot SVG, cloned into every .ia2-bot, then the component self-mounts -->
+  <template id="ia2bot-tmpl">
+    <span class="ia2bot">
+      <svg width="36" height="36" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="install agent">
+        <g class="ia2bot-all">
+          <line x1="24" y1="12" x2="24" y2="6.5" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/>
+          <g transform="translate(24 3)"><g class="ia2bot-tip">
+            <path d="M0 -3.4 L1 -1 L3.4 0 L1 1 L0 3.4 L-1 1 L-3.4 0 L-1 -1 Z" fill="currentColor"/>
+          </g></g>
+          <rect x="5.6" y="20" width="3" height="9" rx="1.5" fill="currentColor"/>
+          <rect x="39.4" y="20" width="3" height="9" rx="1.5" fill="currentColor"/>
+          <rect x="9" y="12" width="30" height="26" rx="8.5" fill="none" stroke="currentColor" stroke-width="2.4"/>
+          <g class="ia2bot-look">
+            <g class="ia2bot-eyes">
+              <circle cx="18" cy="24" r="2.7" fill="currentColor"/>
+              <circle cx="30" cy="24" r="2.7" fill="currentColor"/>
+            </g>
+            <path d="M19.5 30.6 Q24 34 28.5 30.6" stroke="currentColor" stroke-width="1.9" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+          </g>
+          <g class="ia2bot-check" transform="translate(34 33)">
+            <circle r="6.4" fill="currentColor"/>
+            <path d="M-3 0.2 L-0.8 2.4 L3.2 -2.2" fill="none" stroke="#000" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+          </g>
+        </g>
+      </svg>
+    </span>
+  </template>
+  <script>
+    (function () {
+      var tmpl = document.getElementById('ia2bot-tmpl');
+      document.querySelectorAll('.ia2 .ia2-bot').forEach(function (slot) {
+        slot.appendChild(tmpl.content.cloneNode(true));
+      });
+    })();
+  </script>
+  <script src="/assets/install-agent.js" defer></script>
+</body>
+</html>

--- a/styleguide/index.html
+++ b/styleguide/index.html
@@ -99,11 +99,19 @@
 
       <div class="sg-subhead">Type</div>
       <div class="sg-panel">
-        <p style="font-family:var(--font-heading);font-size:40px;line-height:1.05;letter-spacing:-0.02em;margin-bottom:18px;">Kamura — display / headlines</p>
-        <p style="font-family:var(--font);font-size:24px;font-weight:700;margin-bottom:4px;">Basier Circle Bold 700 — H-level UI</p>
-        <p style="font-family:var(--font);font-size:17px;font-weight:600;margin-bottom:4px;">Basier Circle SemiBold 600 — buttons, labels</p>
+        <p style="font-family:var(--font-heading);font-size:48px;line-height:1;letter-spacing:-0.01em;margin-bottom:6px;">95% · 200h → 2h</p>
+        <p style="font-family:var(--font-heading);font-size:28px;line-height:1.05;margin-bottom:18px;color:#555;">Kamura — display serif: the nav wordmark and big metric numbers</p>
+        <p style="font-family:var(--font);font-size:clamp(38px,5vw,56px);font-weight:700;line-height:1.08;letter-spacing:-0.03em;margin-bottom:14px;">Build the one&#8209;person marketing team</p>
+        <p style="font-family:var(--font);font-size:13px;color:#888;margin-bottom:18px;">↑ Hero headlines &amp; section titles are <strong>Basier Circle Bold</strong>, <em>not</em> Kamura.</p>
+        <p style="font-family:var(--font);font-size:17px;font-weight:600;margin-bottom:4px;">Basier Circle SemiBold 600 — buttons, labels, eyebrows</p>
         <p style="font-family:var(--font);font-size:16px;font-weight:400;color:#444;">Basier Circle Regular 400 — body copy. The quick brown fox jumps over the lazy dog.</p>
-        <p class="sg-note"><span class="sg-code">--font-heading</span> = Kamura (serif display) · <span class="sg-code">--font</span> = Basier Circle (weights 400/500/600/700). Fonts load via root-relative <span class="sg-code">@font-face</span> paths so they work from sub-pages.</p>
+        <p class="sg-note"><span class="sg-code">--font-heading</span> = Kamura (serif display — reserved for the wordmark and large numerals). <span class="sg-code">--font</span> = Basier Circle (weights 400/500/600/700) for <strong>everything else, including the hero headline and section titles</strong>. Fonts load via root-relative <span class="sg-code">@font-face</span> paths so they work from sub-pages.</p>
+      </div>
+
+      <div class="sg-subhead">Eyebrow (<span class="sg-code">.eyebrow</span>)</div>
+      <div class="sg-panel">
+        <p class="eyebrow">Custom AI agents for growth</p>
+        <p class="sg-note">The small uppercase kicker above a headline/section title: <span class="sg-code">--red</span>, 12px/700, <span class="sg-code">0.12em</span> tracking. Used in the hero and at the top of most sections. On dark sections it sits above white headings; here on light it keeps its red.</p>
       </div>
 
       <div class="sg-subhead">Radius</div>
@@ -245,7 +253,7 @@
     <!-- ============================= METRIC NUMBERS ============================= -->
     <section class="sg-section" id="metrics">
       <h2>Gradient metric numbers — <span class="sg-code">.metric-card</span></h2>
-      <p class="sg-lead">Big gradient-filled figures used on case studies (<span class="sg-code">/results/</span>). The flame gradient is clipped to the text via <span class="sg-code">background-clip: text</span>. Defined in <span class="sg-code">results.css</span>, laid out in a <span class="sg-code">.cs-metrics</span> grid.</p>
+      <p class="sg-lead">Big <strong>Kamura</strong> (<span class="sg-code">--font-heading</span>) figures used on case studies (<span class="sg-code">/results/</span>) — the display serif's main job besides the wordmark. The flame gradient is clipped to the text via <span class="sg-code">background-clip: text</span>. Defined in <span class="sg-code">results.css</span>, laid out in a <span class="sg-code">.cs-metrics</span> grid.</p>
       <div class="cs-metrics">
         <div class="metric-card">
           <div class="metric-card__value">95%</div>

--- a/styleguide/index.html
+++ b/styleguide/index.html
@@ -67,6 +67,13 @@ layout: null
 .sg-toc a { font-size: 13px; color: #666; }
 .sg-toc a:hover { color: var(--orange); }
 
+/* pinned hover demos — so reviewers see hover-only states without a mouse */
+.sg-pin .card--outline, .sg-pin .card--agent, .sg-pin .card--link {
+  border-color: var(--orange);
+  box-shadow: 0 8px 32px rgba(255, 122, 0, 0.09);
+  transform: translateY(-3px);
+}
+
 /* page-chrome responsiveness (keeps specimens inside narrow viewports) */
 @media (max-width: 640px) {
   .sg-top { padding: 14px 16px; }
@@ -314,6 +321,13 @@ EldurInstallAgent.setState(el, <span class="k">'done'</span>);       <span class
         <div class="card card--dark"><h3>Dark card</h3><p>For black sections. Muted body, <em>yellow</em> emphasis when needed.</p></div>
       </div>
     </div>
+    <div class="sg-block">
+      <span class="sg-label">rest → hover (left is live — hover it; right is pinned to the hover state)</span>
+      <div class="cards cards--2">
+        <a class="card card--outline card--link" href="#cards"><p class="card__eyebrow">Resource</p><h3 class="card__title">Link card (live)</h3><p class="card__excerpt">Hover me — the border turns orange and the whole card lifts 3px.</p></a>
+        <div class="sg-pin"><a class="card card--outline card--link" href="#cards"><p class="card__eyebrow">Resource</p><h3 class="card__title">Link card (pinned hover)</h3><p class="card__excerpt">Orange border + 3px lift + soft orange shadow.</p></a></div>
+      </div>
+    </div>
   </section>
 
   <!-- ============ AGENT CARDS ============ -->
@@ -323,6 +337,14 @@ EldurInstallAgent.setState(el, <span class="k">'done'</span>);       <span class
     <p class="sg-lead">The icon tile now does the agent-bot <strong>wiggle on hover</strong> and the card lifts — the one sanctioned bit of personality, carried over from the Install Agent bot. <strong>Hover a card.</strong></p>
     <div class="sg-stage sg-stage--light">
       <div class="cards cards--3" id="agent-cards"></div>
+    </div>
+    <div class="sg-block">
+      <span class="sg-label">hover state (pinned)</span>
+      <div class="sg-stage sg-stage--light">
+        <div class="sg-pin" style="max-width:320px">
+          <div class="card card--agent"><div class="agent__icon"><svg width="22" height="22" viewBox="0 0 22 22" fill="none"><rect x="2.5" y="4" width="17" height="13" rx="4" stroke="#ff7a00" stroke-width="2"/><circle cx="8" cy="10.5" r="1.4" fill="#ff7a00"/><circle cx="14" cy="10.5" r="1.4" fill="#ff7a00"/><path d="M11 4V1.6M11 1.6a1.3 1.3 0 1 0 0-.01" stroke="#ff7a00" stroke-width="2" stroke-linecap="round"/></svg></div><h3>Pinned hover</h3><p>Orange border + soft orange shadow + 3px lift. The icon wiggle plays only on a real pointer hover.</p></div>
+        </div>
+      </div>
     </div>
   </section>
 

--- a/styles.css
+++ b/styles.css
@@ -228,36 +228,32 @@ img, svg {
 .btn {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
   gap: 10px;
-  padding: 19px 34px;
-  border-radius: 12px;
+  padding: 16px 30px;                /* was 14px 28px */
+  border-radius: 12px;               /* was 100px (pill) */
   font-family: var(--font);
-  font-size: 17px;
-  font-weight: 700;
+  font-size: 16px;                   /* was 15px */
+  font-weight: 700;                  /* was 600 */
   line-height: 1;
   letter-spacing: -0.01em;
   cursor: pointer;
-  transition: transform 0.16s cubic-bezier(0.2, 0.8, 0.2, 1), background 0.18s ease, border-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
+  transition: transform 0.16s cubic-bezier(.2,.8,.2,1), background 0.18s ease, border-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
   text-decoration: none;
   border: 2px solid transparent;
   white-space: nowrap;
 }
-.btn:focus-visible { outline: 2px solid var(--orange); outline-offset: 3px; }
-.btn:hover { transform: translateY(-2px); }   /* the lift */
+.btn:not(.btn--nav):hover { transform: translateY(-2px); }   /* the lift */
 .btn:active { transform: translateY(0); }
+.btn:focus-visible { outline: 2px solid var(--orange); outline-offset: 3px; }
 
-/* wrap trailing/leading icons in <span class="btn__ico"> so they nudge on hover */
-.btn__ico { display: inline-flex; transition: transform 0.18s cubic-bezier(0.2, 0.8, 0.2, 1); }
+/* wrap an icon in <span class="btn__ico"> so it nudges on hover */
+.btn__ico { display: inline-flex; transition: transform 0.18s cubic-bezier(.2,.8,.2,1); }
 .btn:hover .btn__ico { transform: translateX(2px); }
 
-/* sizes */
-.btn--sm { padding: 13px 22px; font-size: 15px; border-radius: 10px; }
-.btn--lg { padding: 23px 42px; font-size: 19px; border-radius: 14px; }
-
 .btn--nav {
-  padding: 10px 22px;
+  padding: 10px 20px;
   font-size: 14px;
+  border-radius: 10px;               /* compact, but matches the new corner */
   background: var(--orange);
   color: var(--white);
   border-color: var(--orange);
@@ -278,14 +274,13 @@ img, svg {
   box-shadow: 0 10px 28px rgba(255, 122, 0, 0.42);
 }
 
-/* flame orange→red gradient, for the loud moments */
+/* NEW — flame orange→red gradient, for the loud moments */
 .btn--gradient {
   background: var(--gradient);
   color: var(--white);
+  border-color: transparent;
 }
-.btn--gradient:hover {
-  box-shadow: 0 12px 30px rgba(238, 15, 15, 0.40);
-}
+.btn--gradient:hover { box-shadow: 0 12px 30px rgba(238, 15, 15, 0.40); }
 
 .btn--ghost {
   background: transparent;
@@ -304,7 +299,7 @@ img, svg {
 }
 .btn--white:hover {
   background: var(--gray);
-  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.18);
 }
 
 .btn--outline-white {
@@ -318,9 +313,8 @@ img, svg {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .btn, .btn__ico { transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease; }
-  .btn:hover, .btn:active { transform: none; }
-  .btn:hover .btn__ico { transform: none; }
+  .btn, .btn__ico { transition: background 0.18s ease, border-color 0.18s ease; }
+  .btn:not(.btn--nav):hover { transform: none; }
 }
 
 /* ============================================
@@ -710,13 +704,12 @@ img, svg {
   flex-direction: column;
   text-decoration: none;
   color: inherit;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.2s cubic-bezier(0.2, 0.8, 0.2, 1);
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
 }
 
 .card--link:hover {
   border-color: var(--orange);
   box-shadow: 0 4px 16px rgba(255, 122, 0, 0.08);
-  transform: translateY(-3px);
 }
 
 .card--link .card__body {
@@ -1131,23 +1124,6 @@ img, svg {
   align-items: center;
   justify-content: center;
   margin-bottom: 20px;
-  /* pivot near the tile's base + GPU hint for the hover wiggle */
-  transform-origin: 50% 78%;
-  will-change: transform;
-}
-
-/* the icon tile does a playful wiggle on hover (echoes the InstallAgent bot) */
-@keyframes agent-icon-wiggle {
-  0%, 100% { transform: rotate(0deg); }
-  22%      { transform: rotate(-7deg); }
-  60%      { transform: rotate(5deg); }
-  82%      { transform: rotate(-2deg); }
-}
-.card--agent:hover .agent__icon { animation: agent-icon-wiggle 0.55s ease-in-out; }
-
-@media (prefers-reduced-motion: reduce) {
-  .card--agent:hover .agent__icon { animation: none; }
-  .card--link:hover { transform: none; }
 }
 
 .card--agent h3 {
@@ -1162,6 +1138,41 @@ img, svg {
   font-size: 15px;
   color: #555555;
   line-height: 1.65;
+}
+
+/* ============================================
+   CARD HOVER MOTION (patch — appended)
+   ============================================ */
+/* pivot near the base + GPU hint */
+.agent__icon {
+  transform-origin: 50% 78%;
+  will-change: transform;
+}
+
+/* the wiggle — same curve as the InstallAgent bot */
+@keyframes agent-icon-wiggle {
+  0%, 100% { transform: rotate(0deg); }
+  22%      { transform: rotate(-7deg); }
+  60%      { transform: rotate(5deg); }
+  82%      { transform: rotate(-2deg); }
+}
+.card--agent:hover .agent__icon { animation: agent-icon-wiggle 0.55s ease-in-out; }
+
+/* agent card lifts on hover (extend its existing transition) */
+.card--agent {
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s cubic-bezier(.2,.8,.2,1);
+}
+.card--agent:hover { transform: translateY(-3px); }
+
+/* blog/resource cards lift too (they already turn the border orange) */
+.card--link {
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.2s cubic-bezier(.2,.8,.2,1);
+}
+.card--link:hover { transform: translateY(-3px); }
+
+@media (prefers-reduced-motion: reduce) {
+  .card--agent:hover .agent__icon { animation: none; }
+  .card--agent:hover, .card--link:hover { transform: none; }
 }
 
 /* ============================================
@@ -1789,6 +1800,12 @@ details[open] > .faq__q::after {
 .ia2--outline .ia2-bot { color: var(--orange); }
 .ia2--outline.is-installing .ia2-bot,
 .ia2--outline.is-done       .ia2-bot { color: var(--white); }
+
+/* ---- label colour per variant/state (explicit — robust on <a> and <button>) ---- */
+.ia2--solid .ia2-label, .ia2--dark .ia2-label { color: var(--white); }
+.ia2--outline .ia2-label { color: var(--orange); }
+.ia2--outline.is-installing .ia2-label,
+.ia2--outline.is-done       .ia2-label { color: var(--white); }
 
 /* ---- hero bot ---- */
 @keyframes ia2-blink { 0%, 90%, 100% { transform: scaleY(1); } 94% { transform: scaleY(0.08); } }

--- a/styles.css
+++ b/styles.css
@@ -228,19 +228,32 @@ img, svg {
 .btn {
   display: inline-flex;
   align-items: center;
-  gap: 8px;
-  padding: 14px 28px;
-  border-radius: 100px;
+  justify-content: center;
+  gap: 10px;
+  padding: 19px 34px;
+  border-radius: 12px;
   font-family: var(--font);
-  font-size: 15px;
-  font-weight: 600;
+  font-size: 17px;
+  font-weight: 700;
   line-height: 1;
+  letter-spacing: -0.01em;
   cursor: pointer;
-  transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
+  transition: transform 0.16s cubic-bezier(0.2, 0.8, 0.2, 1), background 0.18s ease, border-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease;
   text-decoration: none;
   border: 2px solid transparent;
   white-space: nowrap;
 }
+.btn:focus-visible { outline: 2px solid var(--orange); outline-offset: 3px; }
+.btn:hover { transform: translateY(-2px); }   /* the lift */
+.btn:active { transform: translateY(0); }
+
+/* wrap trailing/leading icons in <span class="btn__ico"> so they nudge on hover */
+.btn__ico { display: inline-flex; transition: transform 0.18s cubic-bezier(0.2, 0.8, 0.2, 1); }
+.btn:hover .btn__ico { transform: translateX(2px); }
+
+/* sizes */
+.btn--sm { padding: 13px 22px; font-size: 15px; border-radius: 10px; }
+.btn--lg { padding: 23px 42px; font-size: 19px; border-radius: 14px; }
 
 .btn--nav {
   padding: 10px 22px;
@@ -262,7 +275,16 @@ img, svg {
 .btn--primary:hover {
   background: #cc6200;
   border-color: #cc6200;
-  box-shadow: 0 4px 20px rgba(255, 122, 0, 0.35);
+  box-shadow: 0 10px 28px rgba(255, 122, 0, 0.42);
+}
+
+/* flame orange→red gradient, for the loud moments */
+.btn--gradient {
+  background: var(--gradient);
+  color: var(--white);
+}
+.btn--gradient:hover {
+  box-shadow: 0 12px 30px rgba(238, 15, 15, 0.40);
 }
 
 .btn--ghost {
@@ -293,6 +315,12 @@ img, svg {
 .btn--outline-white:hover {
   border-color: var(--white);
   background: rgba(255, 255, 255, 0.08);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .btn, .btn__ico { transition: background 0.18s ease, border-color 0.18s ease, color 0.18s ease, box-shadow 0.18s ease; }
+  .btn:hover, .btn:active { transform: none; }
+  .btn:hover .btn__ico { transform: none; }
 }
 
 /* ============================================
@@ -682,12 +710,13 @@ img, svg {
   flex-direction: column;
   text-decoration: none;
   color: inherit;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, transform 0.2s cubic-bezier(0.2, 0.8, 0.2, 1);
 }
 
 .card--link:hover {
   border-color: var(--orange);
   box-shadow: 0 4px 16px rgba(255, 122, 0, 0.08);
+  transform: translateY(-3px);
 }
 
 .card--link .card__body {
@@ -1102,6 +1131,23 @@ img, svg {
   align-items: center;
   justify-content: center;
   margin-bottom: 20px;
+  /* pivot near the tile's base + GPU hint for the hover wiggle */
+  transform-origin: 50% 78%;
+  will-change: transform;
+}
+
+/* the icon tile does a playful wiggle on hover (echoes the InstallAgent bot) */
+@keyframes agent-icon-wiggle {
+  0%, 100% { transform: rotate(0deg); }
+  22%      { transform: rotate(-7deg); }
+  60%      { transform: rotate(5deg); }
+  82%      { transform: rotate(-2deg); }
+}
+.card--agent:hover .agent__icon { animation: agent-icon-wiggle 0.55s ease-in-out; }
+
+@media (prefers-reduced-motion: reduce) {
+  .card--agent:hover .agent__icon { animation: none; }
+  .card--link:hover { transform: none; }
 }
 
 .card--agent h3 {
@@ -1691,4 +1737,79 @@ details[open] > .faq__q::after {
   .exit-survey__card {
     padding: 32px 24px 28px;
   }
+}
+
+/* ============================================
+   INSTALL AGENT CTA
+   The hero "install agent" CTA with a personality bot and a built-in
+   install animation. Pairs with assets/install-agent.js. Self-demo on
+   the homepage; the real Stripe + setup-page flow is tracked separately.
+   ============================================ */
+.ia2 {
+  position: relative; isolation: isolate; overflow: hidden;
+  display: inline-flex; align-items: center; gap: 13px;
+  padding: 17px 28px; min-width: 250px;
+  border-radius: 13px;
+  font-family: var(--font); font-size: 17px; font-weight: 700;
+  letter-spacing: -0.01em; line-height: 1;
+  cursor: pointer; border: 2px solid transparent; white-space: nowrap;
+  text-decoration: none;
+  transition: transform 0.16s cubic-bezier(0.2, 0.8, 0.2, 1), box-shadow 0.2s ease, background 0.25s ease, border-color 0.25s ease, color 0.25s ease;
+}
+.ia2:focus-visible { outline: 2px solid var(--orange); outline-offset: 3px; }
+.ia2:hover { transform: translateY(-2px); }
+.ia2:active { transform: translateY(0); }
+.ia2-label { position: relative; z-index: 2; display: flex; flex-direction: column; gap: 3px; text-align: left; }
+.ia2-sub { font-size: 12px; font-weight: 600; letter-spacing: 0.01em; opacity: 0.82; }
+.ia2-bot { position: relative; z-index: 2; display: inline-flex; }
+.ia2-pct { position: relative; z-index: 2; margin-left: auto; font-variant-numeric: tabular-nums; font-size: 15px; opacity: 0.9; }
+.ia2-fill { position: absolute; inset: 0; z-index: 1; transform-origin: left center; transform: scaleX(0); will-change: transform; }
+
+/* default = Direction B: dark button, flame gradient fills L→R */
+.ia2--dark { background: var(--dark); color: var(--white); border-color: rgba(255, 255, 255, 0.16); }
+.ia2--dark:hover { border-color: rgba(255, 255, 255, 0.32); }
+.ia2--dark .ia2-fill { background: var(--gradient); }
+.ia2--dark.is-done { border-color: var(--orange); box-shadow: 0 8px 26px rgba(255, 122, 0, 0.32); }
+
+.ia2--solid { background: var(--orange); color: var(--white); border-color: var(--orange); box-shadow: 0 6px 22px rgba(255, 122, 0, 0.28); }
+.ia2--solid:hover { box-shadow: 0 12px 30px rgba(255, 122, 0, 0.45); }
+.ia2--solid .ia2-fill { background: rgba(0, 0, 0, 0.22); }
+.ia2--solid.is-done { background: var(--dark); border-color: var(--dark); }
+
+.ia2--outline { background: transparent; color: var(--orange); border-color: var(--orange); }
+.ia2--outline:hover { background: var(--orange-dim); }
+.ia2--outline .ia2-fill { background: var(--orange); }
+.ia2--outline.is-installing .ia2-label, .ia2--outline.is-installing .ia2-bot { color: var(--white); }
+.ia2--outline.is-done { background: var(--orange); color: var(--white); border-color: var(--orange); box-shadow: 0 10px 26px rgba(255, 122, 0, 0.4); }
+
+/* ---- bot colour per variant/state ---- */
+.ia2--solid   .ia2-bot { color: var(--white); }
+.ia2--dark    .ia2-bot { color: var(--orange); }
+.ia2--dark.is-installing .ia2-bot { color: var(--white); }
+.ia2--outline .ia2-bot { color: var(--orange); }
+.ia2--outline.is-installing .ia2-bot,
+.ia2--outline.is-done       .ia2-bot { color: var(--white); }
+
+/* ---- hero bot ---- */
+@keyframes ia2-blink { 0%, 90%, 100% { transform: scaleY(1); } 94% { transform: scaleY(0.08); } }
+@keyframes ia2-wiggle { 0%, 100% { transform: rotate(0); } 22% { transform: rotate(-6deg); } 60% { transform: rotate(5deg); } 82% { transform: rotate(-2deg); } }
+@keyframes ia2-bounce { 0%, 100% { transform: translateY(0); } 35% { transform: translateY(-5px); } 65% { transform: translateY(-1px); } }
+@keyframes ia2-pulse { 0%, 100% { opacity: 1; transform: scale(1); } 50% { opacity: 0.45; transform: scale(0.7); } }
+.ia2bot { display: inline-block; line-height: 0; }
+.ia2bot svg { display: block; overflow: visible; }
+.ia2bot-all { transform-box: fill-box; transform-origin: 24px 40px; }
+.ia2bot-eyes { transform-box: fill-box; transform-origin: center; animation: ia2-blink 5.5s infinite; }
+.ia2bot-tip { transform-box: fill-box; transform-origin: center; }
+.ia2:hover .ia2bot-all { animation: ia2-wiggle 0.55s ease-in-out; }
+.ia2bot--working .ia2bot-all { animation: ia2-wiggle 1.1s ease-in-out infinite; }
+.ia2bot--working .ia2bot-tip { animation: ia2-pulse 0.8s ease-in-out infinite; }
+.ia2bot--working .ia2bot-eyes { animation: ia2-blink 1.4s infinite; }
+.ia2bot--done .ia2bot-all { animation: ia2-bounce 0.6s ease-out; }
+
+/* the installed ✓ badge lives in the SVG and is shown only when done */
+.ia2bot-check { display: none; }
+.ia2bot--done .ia2bot-check { display: block; }
+
+@media (prefers-reduced-motion: reduce) {
+  .ia2, .ia2bot-all, .ia2bot-eyes, .ia2bot-tip, .ia2-fill { animation: none !important; transition: none !important; }
 }


### PR DESCRIPTION
Lands the full Eldur Studio design-system package from Claude Design and makes the **coded style guide the single source of truth** (issue #27). Supersedes the earlier hand-derived component values in this branch.

## styles.css — now matches the authoritative repo-token package exactly
- **Buttons:** `padding 16px 30px`, `16px/700`, `.btn--nav` corner `10px` (stays compact), hover lift gated `.btn:not(.btn--nav)` so the nav button doesn't lift, `.btn--gradient` with `border-color: transparent`. Dropped the `sm`/`lg` sizes I had invented (not in the system).
- **Card motion:** `.agent__icon` wiggle + `.card--agent` lift + `.card--link` lift, applied as one appended patch (adds the agent-card lift the earlier version was missing).
- **InstallAgent:** added the package's explicit `.ia2-label` colour rules (robust on the `<a>` Stripe variant).

## results.css — metric numbers reverted to Basier
The package's typography spec is explicit: **Kamura is the wordmark only**, everything else is Basier. The earlier Kamura-metric-numbers change contradicted the source of truth, so it's reverted.

## /styleguide/ — rebuilt as the full living catalog
Replaced the 6-section hand-built page with the package's **12-section** style guide: Brand · Color · Typography · Spacing & Radii · Buttons · Install Agent · Cards · Agent Cards · Packages · Eyebrows/Chips/Highlight · Timeline · FAQ. It's a Jekyll page (`layout: null`) that links the real `/styles.css` and inlines only its own `sg-*` page chrome (page furniture, never shipped in `styles.css`); the script points at `/assets/install-agent.js`. Added a small responsive block to the chrome so specimens stay within phone viewports.

## Docs — the workflow that closes #27
`README.md` and `CLAUDE.md` now document the source-of-truth workflow: `styles.css` = system of record, `/styleguide/` = the contract, and design changes arrive as **repo-token handoffs** (vanilla patches already using `--orange`/`.btn`, not `--es-*`/`.es-btn`) applied via PR and diffed against the style guide — ending the manual remap tax.

## Hero — intentionally unchanged
Left as-is (self-demo InstallAgent + "Schedule a call" + "View packages") per direction. The package's hero→Stripe-link swap stays with **#25** (no real Stripe URL yet).

## Verification
- No horizontal overflow on `/styleguide/` at iPhone SE / iPhone 14 Pro Max / Pixel 5 / desktop, nor on `/`, `/results/`, `/resources/` after the global button change (nav CTA still fits).
- Style guide renders fully against the real CSS: 8 swatches, 3 agent cards, 6 install bots, pinned idle/installing/done specimens; button padding computes to `16px 30px`.
- `npm run check:assets` passes (the `check-public-assets` gate).

Follow-ups still tracked separately: **#25** (Stripe checkout + setup-page states), **#26** (homepage repositioning).

Closes #27.

https://claude.ai/code/session_01CqRuf9TzC61LzYmXYogcNw