### PR TITLE
Auto-fix: bump actions/checkout to v7 in two missing workflow files

### DIFF
--- a/.github/workflows/mobile-layout-check.yml
+++ b/.github/workflows/mobile-layout-check.yml
@@ -33,7 +33,7 @@ jobs:
     # Only run after a *successful* Pages deploy (skip when it failed)
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/notion-sync.yml
+++ b/.github/workflows/notion-sync.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write         # required to push commits
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
## What was fixed

The previous autofix (PR #34) bumped `actions/checkout` from v5 to v7 in `static-asset-check.yml`, but two other workflow files were still running on v6:

- **`.github/workflows/notion-sync.yml`** — the Notion blog sync that runs every 2 hours
- **`.github/workflows/mobile-layout-check.yml`** — the Huginn mobile layout watchdog

Both are now on `actions/checkout@v7`, matching the third workflow file.

**Why this matters:** GitHub Actions deprecates the Node.js runtime version used by older action versions. Using an outdated major version means workflows eventually run on an unsupported runtime, which GitHub can disable without warning.

## What to review

- [`.github/workflows/notion-sync.yml`](.github/workflows/notion-sync.yml) — line 15: `@v6` → `@v7`
- [`.github/workflows/mobile-layout-check.yml`](.github/workflows/mobile-layout-check.yml) — line 36: `@v6` → `@v7`

Two lines changed total.

## What was skipped

| Issue | Reason |
|-------|---------|
| #38 — DataforSEO MCP unavailable | Monitoring tool configuration issue — needs manual investigation, not a code fix |
| #36 — Blog posts missing cross-links | Requires content decisions and editing Notion posts — not auto-fixable |
| #29 — Badge + Eyebrow design system components | Requires design handoff and user decisions |
| #26 — Homepage repositioning | Requires approved copy and pricing decisions |
| #25 — InstallAgent Stripe wiring | Requires a real Stripe checkout URL |
| Open PRs #30, #31, #32, #33 (Dependabot) | All covered by the open PR #34 — no new dependency bumps needed today |
| Code scanning alerts #1, #2 | Both show `state: fixed` — already resolved |

---

*This PR was created automatically by the site health agent. Please review before merging.*