### PR TITLE
Configure DataforSEO hosted MCP for the weekly SEO audit (#38)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "dataforseo": {
+      "type": "http",
+      "url": "https://mcp.dataforseo.com/mcp",
+      "headers": {
+        "Authorization": "Basic ${DATAFORSEO_AUTH_B64}"
+      }
+    }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,19 @@ The script (`scripts/notion-sync.js`) downloads and optimizes images (via `sharp
 
 Required GitHub secrets: `NOTION_API_KEY`, `NOTION_DATABASE_ID`.
 
+## SEO audit (weekly)
+
+A weekly SEO audit runs as a scheduled Claude Code on the web session. It reviews the site and files `seo`-labeled GitHub issues for findings — and, importantly, for its own tool failures (that is the failure-alert mechanism; e.g. issue #38 reported a missing data source).
+
+The audit pulls ranking data from **DataforSEO via its hosted MCP server**, configured in committed `.mcp.json` at the repo root:
+- Endpoint: `https://mcp.dataforseo.com/mcp` (Streamable HTTP transport).
+- Tools used: `dataforseo_labs_google_domain_rank_overview`, `dataforseo_labs_google_ranked_keywords`.
+- Auth: the env var `DATAFORSEO_AUTH_B64` — base64 of the DataforSEO **API** `login:password` (not the dashboard login; the API Access dashboard provides a pre-encoded token). It is set in the **Claude Code web environment**, never committed (this repo is public — `.mcp.json` only references the var).
+- The first session to use the project `.mcp.json` may need to approve/trust the server.
+- Manual fallback for ranking data: https://app.dataforseo.com.
+
+> `.mcp.json` configures DataforSEO for any Claude Code session opened in this repo with `DATAFORSEO_AUTH_B64` set — it does not host the server (DataforSEO does). Claude Code supports remote `http` MCP servers natively; if the http transport ever fails, the `mcp-remote` npx bridge wrapping the same URL is the documented fallback.
+
 ## Jekyll front matter fields
 
 Every `_posts/*.md` file must have these fields or the sync will skip it:

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -247,6 +247,16 @@ Repo → Settings → Secrets and variables → Actions:
 | `NOTION_API_KEY` | Notion integration token (notion.so/my-integrations) |
 | `NOTION_DATABASE_ID` | `ce0d53fdc6a2489a8201330e13bd3515` |
 
+### Claude Code web environment variables
+
+The weekly SEO audit (a scheduled Claude Code web session, see `CLAUDE.md`) needs DataforSEO's hosted MCP. This is **not** a GitHub Actions secret — set it as a **Claude Code web environment variable** ([docs](https://code.claude.com/docs/en/claude-code-on-the-web)):
+
+| Variable | Value |
+|---|---|
+| `DATAFORSEO_AUTH_B64` | base64 of the DataforSEO **API** `login:password` (API Access dashboard → "Send by Email" gives a pre-encoded token) |
+
+The endpoint and auth wiring live in committed `.mcp.json` (env-var reference only — no secret in the repo).
+
 ---
 
 ## Re-setup checklist


### PR DESCRIPTION
## What & why

Fixes the root cause of #38. The weekly SEO audit (a scheduled Claude Code web session) failed to reach DataforSEO and filed #38 because **DataforSEO was never configured in version control** — it only existed as ad-hoc/local config, so it silently vanished between runs.

This makes DataforSEO a reproducible dependency using its **hosted MCP endpoint** (zero infra), with **no secret in this public repo**.

## Changes

- **`.mcp.json`** (new) — remote HTTP MCP server pointing at `https://mcp.dataforseo.com/mcp`, auth via the `${DATAFORSEO_AUTH_B64}` env var (reference only — no token committed).
- **`CLAUDE.md`** — new "SEO audit (weekly)" section documenting the audit, its DataforSEO dependency, and the required env var.
- **`DEPLOYMENT.md`** — notes `DATAFORSEO_AUTH_B64` as a Claude Code web environment variable (distinct from the GitHub Actions secrets).

## No site impact

Tooling/config only — no page, CSS, or Jekyll content changes. GitHub Pages deploys from `main`, so the live site is unaffected.

## Required before this works (manual, owner-only)

Set `DATAFORSEO_AUTH_B64` (base64 of your DataforSEO **API** `login:password`) in the Claude Code web environment. The committed config only references it.

## Verification

- [x] `.mcp.json` is valid JSON
- [x] No secret committed (`git grep DATAFORSEO` shows only `${...}` references + prose)
- [ ] With the env var set: `dataforseo_labs_google_ranked_keywords` / `dataforseo_labs_google_domain_rank_overview` tools appear, and a ranked-keywords call for `eldur.studio` returns data (the exact thing that failed in #38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PsSUxr3cPik3Tw5mowwnwE)_