### PR TITLE
Auto-fix: add twitter:title and twitter:description to case study pages

### DIFF
--- a/results/people-enrichment-agent/index.html
+++ b/results/people-enrichment-agent/index.html
@@ -18,6 +18,8 @@
   <meta name="twitter:image" content="https://eldur.studio/results/people-enrichment-agent/cover.png">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@eldur_studio">
+  <meta name="twitter:title" content="Lead Enrichment Agent with Explorium and Notion — Eldur Studio">
+  <meta name="twitter:description" content="We replaced 200 hours of LinkedIn research with a 2-hour automation. 400+ VC contacts enriched at 95% match rate.">
   <link rel="canonical" href="https://eldur.studio/results/people-enrichment-agent/">
   <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/styles.css">

--- a/results/scalapay-webflow-directory-headless-cms/index.html
+++ b/results/scalapay-webflow-directory-headless-cms/index.html
@@ -15,6 +15,8 @@
   <meta property="og:image" content="https://eldur.studio/results/scalapay-webflow-directory-headless-cms/filters.webp">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@eldur_studio">
+  <meta name="twitter:title" content="Scaling Scalapay's Shopping Directory with Webflow and Sanity — Eldur Studio">
+  <meta name="twitter:description" content="Webflow CMS hit its limits at thousands of listings. We kept Webflow for marketing speed, moved directory data into Sanity, and shipped a discovery UX that scaled.">
   <meta name="twitter:image" content="https://eldur.studio/results/scalapay-webflow-directory-headless-cms/filters.webp">
   <link rel="canonical" href="https://eldur.studio/results/scalapay-webflow-directory-headless-cms/">
   <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">


### PR DESCRIPTION
## What was fixed

**Issue #54 — Case study pages missing twitter:title and twitter:description**

Both case study pages (`/results/people-enrichment-agent/` and `/results/scalapay-webflow-directory-headless-cms/`) had Twitter card tags for `card`, `site`, and `image`, but were missing `twitter:title` and `twitter:description`. These were added using the same text as the existing `og:title` and `og:description` tags already on each page.

Twitter/X falls back to OG tags when the Twitter-specific ones are absent, so sharing was still working — but without explicit tags you can't control the title/description independently per platform if needed later.

## What to review

- `results/people-enrichment-agent/index.html` — lines 21–22 (new)
- `results/scalapay-webflow-directory-headless-cms/index.html` — lines 18–19 (new)

Only 2 lines added to each file, immediately after the existing `twitter:site` tag.

## What was skipped

The following issues were found but NOT fixed in this PR:

| Issue | Reason not fixed |
|-------|-----------------|
| #56 — eldur-ai-agents-hero.png needs WebP version | Requires converting a binary image file — can't be done automatically without the source image |
| #55 — Homepage title too short | Requires a content/keyword decision (which phrase to add) — too subjective to automate |
| #53 — Blog posts don't cross-link to case studies | Requires deciding which anchor text and placement within existing article bodies |
| #51 — Zero DataforSEO ranking data | Requires manual Google Search Console access — external tool, not fixable in code |
| #29 — Badge + Eyebrow design system | Requires a design handoff and visual review |
| #26 — Homepage repositioning | Requires strategic content decisions (copy, pricing, branding) |
| #25 — InstallAgent Stripe wiring | Requires a real Stripe checkout URL from the user |

---

This PR was created automatically by the site health agent. Please review before merging.