### PR TITLE
Auto-fix: add missing internal links between blog posts and case studies

### DIFF
--- a/_posts/2026-03-03-no-code-to-ai-first-operators-marketing-model.md
+++ b/_posts/2026-03-03-no-code-to-ai-first-operators-marketing-model.md
@@ -99,7 +99,7 @@ Companies do not need more vendors, and they definitely do not need more AI tool
 ## What did not change: durable systems still matter
 
 
-We have been building apps and automations for clients for five years. Before LLMs, those systems were not "AI" in any trendy sense. They were business logic plus automation tools like Zapier and Make, and those tools are still thriving, in many ways 10× more powerful than they were when we started.
+We have been building apps and automations for clients for five years. Before LLMs, those systems were not "AI" in any trendy sense. They were business logic plus automation tools like Zapier and Make, and those tools are still thriving, in many ways 10× more powerful than they were when we started. You can see examples of what we've shipped in our [case studies](/results/).
 
 
 The lesson from five years of shipping real systems is straightforward: **generating output is not the hard part. Scaling, measuring, and improving that output is.** We also learned to spot the difference between tools that look fast in demos and tools that can actually handle complexity, traffic, and maintenance in production.

--- a/results/scalapay-webflow-directory-headless-cms/index.html
+++ b/results/scalapay-webflow-directory-headless-cms/index.html
@@ -414,6 +414,7 @@
       <div class="cs-results-prose">
         <h3>The underlying shift</h3>
         <p>Scalapay didn't need a new website. They needed to separate "content that belongs to a product" from "content that belongs to marketing." Once that line was clear, the architecture followed. Sanity handles the product data. Webflow handles the marketing pages. The API keeps them in sync. Each tool does what it's actually good at.</p>
+        <p>For more on where Webflow's own tooling is headed, read <a href="/resources/claude-webflow-dev-webflow-designer-mcp/">Can Claude be your Webflow dev? A look at the updated MCP →</a></p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## What was fixed

**Issue #53 — Blog posts don't cross-link to case study pages** (2 of 3 gaps remained; the third had already been fixed manually)

1. The blog post *"The new Eldur Studio: From No-Code to AI-First Operators"* had no link to the `/results/` case studies page, even though it talks about the systems we've shipped for clients. Added one sentence pointing readers to `/results/`.
2. The Scalapay case study page had no link back to any blog post, even though it's about Webflow architecture. Added a short "further reading" line linking to the related Webflow MCP blog post.

## What to review

- [`_posts/2026-03-03-no-code-to-ai-first-operators-marketing-model.md`](https://github.com/UberVero/ES2website/blob/autofix/2026-07-03/_posts/2026-03-03-no-code-to-ai-first-operators-marketing-model.md) — one added sentence in the "durable systems still matter" section, linking to `/results/`.
- [`results/scalapay-webflow-directory-headless-cms/index.html`](https://github.com/UberVero/ES2website/blob/autofix/2026-07-03/results/scalapay-webflow-directory-headless-cms/index.html) — one added paragraph linking to `/resources/claude-webflow-dev-webflow-designer-mcp/`.

## What was skipped

- **Issue #53, item 1** (link from the enrichment blog post to its case study) — already fixed on `main` (Veronica added it directly, synced in via Notion on 2026-06-24). No action needed.
- **Issue #56** (missing WebP version of a hero image) — already has an open PR (#58) from a previous run. Not duplicated.
- **Issue #54** (missing Twitter meta tags on case studies) — already has an open PR (#57) from a previous run. Not duplicated.
- **Issue #55** (homepage title tag length) — skipped. Fixing it well requires choosing which keyword to prioritize, which is a strategy call, not a mechanical fix.
- **Issue #51** (zero ranking data in DataforSEO) — skipped. This needs a human to check Google Search Console; nothing in the code is broken.
- **Issues #29, #26, #25** — skipped. These are design/content/pricing decisions (new components, homepage repositioning, Stripe checkout wiring), not code bugs.
- **PR #59** (Dependabot bump of `sharp` 0.35.2 → 0.35.3) — already an open PR from Dependabot itself; just needs a human to review and merge it, no additional fix needed.
- **Code scanning alerts** (2 CodeQL findings in `scripts/notion-sync.js`) — both already show `state: fixed`, no action needed.
- **CI** — the last 3 mobile-layout-check runs all passed, no failures to fix.

This PR was created automatically by the site health agent. Please review before merging.