### PR TITLE
Add tab attention title and favicon on inactive tabs

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -7,6 +7,7 @@
   <link rel="stylesheet" href="/styles.css">
   <link rel="stylesheet" href="/blog.css">
   <script src="https://cdn.usefathom.com/script.js" data-site="FYROQRHW" defer></script>
+  <script src="/assets/tab-attention.js" defer></script>
 
   <!-- jekyll-seo-tag: auto-generates title, og:title, og:description, og:image, twitter:card, canonical, article:published_time -->
   {% seo %}

--- a/assets/favicon-alert.svg
+++ b/assets/favicon-alert.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><circle cx="50" cy="50" r="32" fill="#ff7a00"/></svg>

--- a/assets/tab-attention.js
+++ b/assets/tab-attention.js
@@ -1,0 +1,24 @@
+/* ============================================================
+   Eldur Studio — Tab attention
+   When the visitor leaves the tab, swap the title and favicon
+   so the inactive tab stands out. Restore both on return.
+   ============================================================ */
+(function () {
+  var awayTitle = 'Come back — Eldur Studio';
+  // Snapshot at hide time (not load): safer if anything rewrites the title.
+  var realTitle = document.title;
+  var icon = document.querySelector('link[rel="icon"][type="image/svg+xml"]');
+  var realIcon = icon ? icon.getAttribute('href') : null;
+  var alertIcon = '/assets/favicon-alert.svg';
+
+  document.addEventListener('visibilitychange', function () {
+    if (document.hidden) {
+      realTitle = document.title;
+      document.title = awayTitle;
+      if (icon) icon.setAttribute('href', alertIcon);
+    } else {
+      document.title = realTitle;
+      if (icon && realIcon) icon.setAttribute('href', realIcon);
+    }
+  });
+})();

--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@ layout: null
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="styles.css">
   <script src="https://cdn.usefathom.com/script.js" data-site="FYROQRHW" defer></script>
+  <script src="assets/tab-attention.js" defer></script>
   <link rel="canonical" href="https://eldur.studio/">
   <meta property="og:site_name" content="Eldur Studio">
   <meta property="og:type" content="website">

--- a/resources/index.html
+++ b/resources/index.html
@@ -29,6 +29,7 @@ permalink: /resources/
   <link rel="stylesheet" href="/styles.css">
   <link rel="stylesheet" href="/blog.css">
   <script src="https://cdn.usefathom.com/script.js" data-site="FYROQRHW" defer></script>
+  <script src="/assets/tab-attention.js" defer></script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/results/index.html
+++ b/results/index.html
@@ -30,6 +30,7 @@ permalink: /results/
   <link rel="stylesheet" href="/blog.css">
   <link rel="stylesheet" href="/results.css">
   <script src="https://cdn.usefathom.com/script.js" data-site="FYROQRHW" defer></script>
+  <script src="/assets/tab-attention.js" defer></script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/results/people-enrichment-agent/index.html
+++ b/results/people-enrichment-agent/index.html
@@ -25,6 +25,7 @@
   <link rel="stylesheet" href="/styles.css">
   <link rel="stylesheet" href="/results.css">
   <script src="https://cdn.usefathom.com/script.js" data-site="FYROQRHW" defer></script>
+  <script src="/assets/tab-attention.js" defer></script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",

--- a/results/scalapay-webflow-directory-headless-cms/index.html
+++ b/results/scalapay-webflow-directory-headless-cms/index.html
@@ -23,6 +23,7 @@
   <link rel="stylesheet" href="/styles.css">
   <link rel="stylesheet" href="/results.css">
   <script src="https://cdn.usefathom.com/script.js" data-site="FYROQRHW" defer></script>
+  <script src="/assets/tab-attention.js" defer></script>
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds the getleads-style Page Visibility tab trick: when a visitor switches away, the tab title becomes `Come back — Eldur Studio` and the favicon swaps to a brand-orange alert dot; both restore on return.

## Changes
- New `assets/tab-attention.js` (deferred, ~20 lines)
- New `assets/favicon-alert.svg` (orange circle using `--orange` / `#ff7a00`)
- Wired into homepage, resources, results listing + case studies, and blog post layout

## Verification
Smoke-tested locally against `http://localhost:3000` with Playwright:
- Chromium: title + favicon swap and restore passed
- WebKit (Safari engine): title + favicon swap and restore passed
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6d12f41-3c51-4536-a198-2c66a1d85b6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6d12f41-3c51-4536-a198-2c66a1d85b6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

