### PR TITLE
Add plugin support, privacy, and terms pages

### DIFF
--- a/_layouts/legal.html
+++ b/_layouts/legal.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ page.title }} — Eldur Studio</title>
+  <meta name="description" content="{{ page.description }}">
+  <meta property="og:site_name" content="Eldur Studio">
+  <meta property="og:title" content="{{ page.title }} — Eldur Studio">
+  <meta property="og:description" content="{{ page.description }}">
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://eldur.studio{{ page.url }}">
+  <link rel="canonical" href="https://eldur.studio{{ page.url }}">
+  <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/blog.css">
+  <script src="https://cdn.usefathom.com/script.js" data-site="FYROQRHW" defer></script>
+  <script src="/assets/tab-attention.js" defer></script>
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav__inner">
+      <a href="/" class="nav__logo">
+        <svg height="32" viewBox="488 316 133 148" fill="white" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+          <path d="M583.872 365.062C603.228 376.639 618.027 431.886 585.114 444.567C544.201 460.331 550.034 407.457 550.034 407.457C550.347 415.382 557.671 415.234 561.169 414.704C563.752 414.313 566.418 414.595 568.773 415.725C570.003 416.317 571.227 417.158 572.214 418.354C575.502 422.347 581.37 421.356 584.883 417.251C586.097 415.834 586.38 413.87 585.131 412.484L547.289 371.905C544.268 377.583 546.869 384.253 546.869 384.253C546.869 384.253 508.999 408.619 524.336 447.886C524.336 447.886 504.045 444.465 496.94 426.328C489.835 408.192 495.074 390.803 510.78 378.274C526.487 365.747 547.802 347.23 539.385 320.113C539.385 320.113 583.964 330.71 571.972 376.547C571.972 376.547 580.934 373.887 583.872 365.062"/>
+        </svg>
+        <span class="nav__wordmark">Eldur Studio</span>
+      </a>
+      <div class="nav__links">
+        <a href="/results/" class="nav__link">Results</a>
+        <a href="/resources/" class="nav__link">Resources</a>
+        <a href="mailto:info@eldur.studio" class="btn btn--nav">Contact us</a>
+      </div>
+    </div>
+  </nav>
+
+  <header class="post-hero">
+    <div class="container--narrow">
+      <p class="eyebrow">Eldur Studio</p>
+      <h1 class="post__title">{{ page.title }}</h1>
+      <p class="post__lead">{{ page.description }}</p>
+      {% if page.effective_date %}<p class="post__meta">Effective {{ page.effective_date }}</p>{% endif %}
+    </div>
+  </header>
+
+  <main class="post-body">
+    <div class="container--narrow">
+      {{ content }}
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container footer__inner">
+      <div class="footer__brand">
+        <a href="/" class="nav__logo"><span class="nav__wordmark">Eldur Studio</span></a>
+        <p>Build the one-person marketing team.</p>
+      </div>
+      <nav class="footer__links" aria-label="Footer navigation">
+        <a href="/support/">Support</a>
+        <a href="/privacy/">Privacy</a>
+        <a href="/terms/">Terms</a>
+        <a href="mailto:info@eldur.studio">info@eldur.studio</a>
+      </nav>
+    </div>
+  </footer>
+</body>
+</html>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -321,6 +321,9 @@
       <nav class="footer__links" aria-label="Footer navigation">
         <a href="/results/">Results</a>
         <a href="/resources/">Resources</a>
+        <a href="/support/">Support</a>
+        <a href="/privacy/">Privacy</a>
+        <a href="/terms/">Terms</a>
         <a href="https://booking.akiflow.com/veronica-es-new" target="_blank" rel="noopener">Schedule a call</a>
         <a href="https://eldur.studio" target="_blank" rel="noopener">eldur.studio</a>
         <a href="mailto:info@eldur.studio" class="footer__contact">

--- a/index.html
+++ b/index.html
@@ -591,6 +591,9 @@ layout: null
       <nav class="footer__links" aria-label="Footer navigation">
         <a href="/results/">Results</a>
         <a href="/resources/">Resources</a>
+        <a href="/support/">Support</a>
+        <a href="/privacy/">Privacy</a>
+        <a href="/terms/">Terms</a>
         <a href="https://booking.akiflow.com/veronica-es-new" target="_blank" rel="noopener" onclick="fathom.trackEvent('schedule-call')">Schedule a call</a>
         <a href="https://www.eldur.studio" target="_blank" rel="noopener">eldur.studio</a>
         <a href="mailto:info@eldur.studio" class="footer__contact">

--- a/privacy/index.md
+++ b/privacy/index.md
@@ -1,0 +1,45 @@
+---
+layout: legal
+title: Privacy Policy
+description: How Eldur Studio handles information related to its website and the B2B Messaging Workshop plugin.
+permalink: /privacy/
+effective_date: August 26, 2026
+---
+
+This policy applies to the Eldur Studio website and the **B2B Messaging Workshop** plugin published by Eldur Studio LLC.
+
+## The workshop plugin
+
+The B2B Messaging Workshop is a skills-only plugin. It provides instructions that run inside the OpenAI product where you install it. The plugin does not operate an Eldur-hosted server, create an Eldur account, or send your workshop answers to Eldur Studio.
+
+Your conversations, uploaded files, and connected services are handled by OpenAI and any service you choose to connect, under your agreements and privacy settings with those providers. If you choose to export workshop material to a connected service such as Notion, that action only happens after you approve it.
+
+Do not include confidential, regulated, or sensitive personal information in a workshop unless you are authorized to process it in the OpenAI product you are using.
+
+## Information you send us
+
+If you contact Eldur Studio for support, we receive the information you choose to provide, such as your name, email address, message, plugin version, and troubleshooting details. We use it to respond, diagnose problems, improve the plugin, and keep appropriate business records.
+
+Please do not email passwords, API keys, customer records, or the contents of private workshops.
+
+## Website analytics
+
+Eldur Studio uses Fathom Analytics to understand aggregate website traffic. Fathom is designed to provide website analytics without tracking people across websites. We use these measurements to understand which pages are useful and improve the site.
+
+## How information is shared
+
+Eldur Studio does not sell personal information. We may share limited information with service providers that help us operate our website and email, when required by law, or when necessary to protect our rights and users.
+
+## Retention and security
+
+We retain support correspondence and related business records only as long as reasonably necessary for support, security, legal, and operational purposes. No internet or email system can be guaranteed completely secure.
+
+## Your choices
+
+You may ask to access, correct, or delete personal information you sent directly to Eldur Studio, subject to applicable law and legitimate recordkeeping needs.
+
+## Contact
+
+Questions or privacy requests can be sent to [info@eldur.studio](mailto:info@eldur.studio).
+
+We may update this policy as the plugin or applicable requirements change. The effective date above identifies the current version.

--- a/resources/index.html
+++ b/resources/index.html
@@ -136,6 +136,9 @@ permalink: /resources/
       <nav class="footer__links" aria-label="Footer navigation">
         <a href="/results/">Results</a>
         <a href="/resources/">Resources</a>
+        <a href="/support/">Support</a>
+        <a href="/privacy/">Privacy</a>
+        <a href="/terms/">Terms</a>
         <a href="https://booking.akiflow.com/veronica-es-new" target="_blank" rel="noopener">Schedule a call</a>
         <a href="https://eldur.studio" target="_blank" rel="noopener">eldur.studio</a>
         <a href="mailto:info@eldur.studio" class="footer__contact">

--- a/support/index.md
+++ b/support/index.md
@@ -1,0 +1,28 @@
+---
+layout: legal
+title: Plugin Support
+description: Help with installing and using Eldur Studio's B2B Messaging Workshop plugin.
+permalink: /support/
+---
+
+Need help with the **B2B Messaging Workshop**? Email [info@eldur.studio](mailto:info@eldur.studio). We aim to reply within two business days.
+
+## What to include
+
+To help us diagnose the problem, include:
+
+- where you installed the plugin, such as ChatGPT desktop or Codex;
+- the plugin version, if it is shown;
+- what you expected to happen;
+- the exact error message or a screenshot with private information removed; and
+- the steps that produced the problem.
+
+Do not send passwords, API keys, customer records, or confidential workshop content.
+
+## Useful links
+
+- [B2B Messaging Workshop on GitHub](https://github.com/UberVero/messaging-workshop-b2b)
+- [Installation instructions](https://github.com/UberVero/messaging-workshop-b2b#install-in-chatgpt-desktop)
+- [Privacy Policy](/privacy/)
+- [Terms of Use](/terms/)
+- [Workshop Use License](https://github.com/UberVero/messaging-workshop-b2b/blob/main/LICENSE)

--- a/terms/index.md
+++ b/terms/index.md
@@ -1,0 +1,43 @@
+---
+layout: legal
+title: Terms of Use
+description: Terms for the B2B Messaging Workshop plugin and related Eldur Studio materials.
+permalink: /terms/
+effective_date: August 26, 2026
+---
+
+These terms govern your use of the **B2B Messaging Workshop** plugin and related materials published by Eldur Studio LLC. By using the plugin, you agree to these terms.
+
+## License and permitted use
+
+The plugin is provided under the [Eldur Studio Workshop Use License](https://github.com/UberVero/messaging-workshop-b2b/blob/main/LICENSE). You may use it for yourself or within your organization and may use the original outputs created from your inputs in your business. Conducting paid workshops or client services requires separate written permission from Eldur Studio.
+
+The framework, instructions, examples, templates, and plugin source remain the intellectual property of Eldur Studio LLC. You may not redistribute, publish, sublicense, sell, clone, or offer them as a competing workshop or software product except with Eldur Studio's written permission.
+
+## Your content and responsibilities
+
+You retain your rights in the information you provide and in original outputs created from it. You are responsible for having permission to use any information you enter, for reviewing outputs before relying on or publishing them, and for complying with applicable laws and third-party rights.
+
+## Third-party services
+
+The plugin runs within an OpenAI product. OpenAI and any connected services, such as Notion, are independent third parties governed by their own terms and privacy policies. Eldur Studio does not control their availability, security, output, or data handling.
+
+## No professional advice
+
+Workshop suggestions are general business and marketing information. They are not legal, financial, or other regulated professional advice.
+
+## No warranties
+
+The plugin and related materials are provided “as is” and “as available,” without warranties of any kind to the fullest extent permitted by law. AI-generated output can be incomplete or inaccurate, and you should review it before use.
+
+## Limitation of liability
+
+To the fullest extent permitted by law, Eldur Studio LLC will not be liable for indirect, incidental, special, consequential, or punitive damages, loss of profits, data, goodwill, or business opportunity arising from use of the plugin. Eldur Studio's total liability for claims relating to the plugin will not exceed the amount you paid Eldur Studio for the plugin during the twelve months before the claim.
+
+## Changes and termination
+
+We may update, suspend, or discontinue the plugin and may update these terms. The effective date above identifies the current version. You may stop using and uninstall the plugin at any time. Rights and obligations that by their nature should survive termination will survive.
+
+## Contact
+
+Questions about these terms can be sent to [info@eldur.studio](mailto:info@eldur.studio).


### PR DESCRIPTION
## Summary

- add public Support, Privacy Policy, and Terms of Use pages for the B2B Messaging Workshop
- explain the skills-only data flow and support contact
- add the required public URLs to the site's main footers

## Why

These pages are required for the OpenAI public Plugins Directory submission.

## Checks

- git diff --check passes
- terms match the repository's Eldur Studio Workshop Use License
- no Webflow site or production custom-domain configuration is changed