### PR TITLE
Point Scalapay case study to Webflow MCP 2.0 post

### DIFF
--- a/results/scalapay-webflow-directory-headless-cms/index.html
+++ b/results/scalapay-webflow-directory-headless-cms/index.html
@@ -417,7 +417,7 @@
       <div class="cs-results-prose">
         <h3>The underlying shift</h3>
         <p>Scalapay didn't need a new website. They needed to separate "content that belongs to a product" from "content that belongs to marketing." Once that line was clear, the architecture followed. Sanity handles the product data. Webflow handles the marketing pages. The API keeps them in sync. Each tool does what it's actually good at.</p>
-        <p>For more on where Webflow's own tooling is headed, read <a href="/resources/claude-webflow-dev-webflow-designer-mcp/">Can Claude be your Webflow dev? A look at the updated MCP →</a></p>
+        <p>For more on where Webflow's own tooling is headed, read <a href="/resources/webflow-mcp-2-data-designer-api/">Webflow MCP 2.0: game changing release →</a></p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## What

Updates the one outbound editorial link in the Scalapay case study (`results/scalapay-webflow-directory-headless-cms/index.html`, "The underlying shift" section) from the April 2026 MCP review to the current **Webflow MCP 2.0: game changing release** post.

```diff
-<a href="/resources/claude-webflow-dev-webflow-designer-mcp/">Can Claude be your Webflow dev? A look at the updated MCP →</a>
+<a href="/resources/webflow-mcp-2-data-designer-api/">Webflow MCP 2.0: game changing release →</a>
```

## Why

Follow-up to the `monthly-internal-links` scheduled audit. The April post is now two MCP versions behind; the 2.0 post opens by linking back to it, so readers still get the full arc but land on the current state first.

## QA

- `permalink: /resources/:slug/` in `_config.yml` → target resolves to `/resources/webflow-mcp-2-data-designer-api/`
- `_posts/2026-08-18-webflow-mcp-2-data-designer-api.md` exists with `slug: "webflow-mcp-2-data-designer-api"`
- One-line href + anchor-text swap; no markup structure or Liquid change
- Old target page still reachable (linked from the new target post's "Update:" note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)